### PR TITLE
Fix withLatestFrom and takeWhen interfaces.

### DIFF
--- a/ReactiveExtensions/operators/TakeWhen.swift
+++ b/ReactiveExtensions/operators/TakeWhen.swift
@@ -19,13 +19,13 @@ public extension SignalProducerType {
 
   /// Emits the latest value of `self` when `other` emits.
   @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func takeWhen <U> (other: SignalProducer<U, Error>) -> SignalProducer<Value, Error> {
-    return lift(Signal.takeWhen)(other)
+  public func takeWhen <U> (other: Signal<U, Error>) -> Signal<Value, Error> {
+    return other.withLatestFrom(self.producer).map { $0.1 }
   }
 
   /// Emits the latest value of `self` when `other` emits.
   @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func takeWhen <U> (other: Signal<U, Error>) -> SignalProducer<Value, Error> {
-    return lift { $0.takeWhen(other) }
+  public func takePairWhen <U> (other: Signal<U, Error>) -> Signal<(Value, U), Error> {
+    return other.withLatestFrom(self.producer).map { ($0.1, $0.0) }
   }
 }

--- a/ReactiveExtensions/operators/WithLatestFrom.swift
+++ b/ReactiveExtensions/operators/WithLatestFrom.swift
@@ -2,7 +2,14 @@ import ReactiveCocoa
 
 public extension SignalType {
 
-  /// Combines values from two signals only when `self` emits.
+  /**
+   Transforms the signal into one that emits the most recent values of `self` and `other` only when `self`
+   emits.
+
+   - parameter other: A signal.
+
+   - returns: A new signal.
+   */
   @warn_unused_result(message="Did you forget to call `observe` on the signal?")
   public func withLatestFrom <U, OtherError: ErrorType> (other: Signal<U, OtherError>) -> Signal<(Value, U), OtherError> {
 
@@ -37,7 +44,7 @@ public extension SignalType {
           }
           lock.unlock()
         case .Failed, .Completed, .Interrupted:
-          // don't fail, complete or interrupt when the sample does
+          // don't fail, complete or interrupt when the other does
           break;
         }
       }
@@ -45,13 +52,55 @@ public extension SignalType {
       return disposable
     }
   }
-}
 
-public extension SignalProducerType {
+  /**
+   Transforms the signal into one that emits the most recent values of `self` and `other` only when `self`
+   emits.
 
-  /// Combines values from two signals only when `other` emits.
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func withLatestFrom <U> (other: SignalProducer<U, Error>) -> SignalProducer<(Value, U), Error> {
-    return lift(Signal.combineLatestWith)(other)
+   - parameter other: A producer.
+
+   - returns: A new signal.
+   */
+  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  public func withLatestFrom <U, OtherError: ErrorType> (other: SignalProducer<U, OtherError>) -> Signal<(Value, U), OtherError> {
+
+    return Signal { observer in
+      let lock = NSLock()
+      lock.name = "org.reactivecocoa.ReactiveCocoa.withLatestFrom"
+
+      let disposable = CompositeDisposable()
+      var latestValue: U? = nil
+
+      disposable += other.start { event in
+        switch event {
+        case let .Next(value):
+          lock.lock()
+          latestValue = value
+          lock.unlock()
+        case let .Failed(error):
+          observer.sendFailed(error)
+        case .Completed:
+          observer.sendCompleted()
+        case .Interrupted:
+          observer.sendInterrupted()
+        }
+      }
+
+      disposable += self.signal.observe { event in
+        switch event {
+        case let .Next(value):
+          lock.lock()
+          if let latestValue = latestValue {
+            observer.sendNext((value, latestValue))
+          }
+          lock.unlock()
+        case .Failed, .Completed, .Interrupted:
+          // don't fail, complete or interrupt when the other does
+          break;
+        }
+      }
+
+      return disposable
+    }
   }
 }

--- a/ReactiveExtensionsTests/operators/WithLatestFromTests.swift
+++ b/ReactiveExtensionsTests/operators/WithLatestFromTests.swift
@@ -6,7 +6,7 @@ import Result
 
 final class WithLatestFromTests : XCTestCase {
 
-  func testStandard() {
+  func testWithLatestFromSignal() {
     let (source, sourceObserver) = Signal<Int, NoError>.pipe()
     let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
     let withLatestFrom = sample.withLatestFrom(source)
@@ -32,7 +32,7 @@ final class WithLatestFromTests : XCTestCase {
     test.assertDidComplete()
   }
 
-  func testWithSourceCompleting() {
+  func testWithLatestFromSignal_SourceCompleting() {
     let (source, sourceObserver) = Signal<Int, SomeError>.pipe()
     let (sample, sampleObserver) = Signal<Int, SomeError>.pipe()
     let withLatestFrom = sample.withLatestFrom(source)
@@ -47,7 +47,7 @@ final class WithLatestFromTests : XCTestCase {
     XCTAssert(test.didComplete)
   }
 
-  func testWithSourceErroring() {
+  func testWithLatestFromSignal_SourceErroring() {
     let (source, sourceObserver) = Signal<Int, SomeError>.pipe()
     let (sample, sampleObserver) = Signal<Int, SomeError>.pipe()
     let withLatestFrom = sample.withLatestFrom(source)
@@ -62,7 +62,7 @@ final class WithLatestFromTests : XCTestCase {
     XCTAssert(test.didFail)
   }
 
-  func testWithSourceInterrupted() {
+  func testWithLatestFromSignal_SourceInterrupted() {
     let (source, sourceObserver) = Signal<Int, NoError>.pipe()
     let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
     let withLatestFrom = sample.withLatestFrom(source)
@@ -77,7 +77,7 @@ final class WithLatestFromTests : XCTestCase {
     test.assertDidInterrupt()
   }
 
-  func testWithSampleErroring() {
+  func testWithLatestFromSignal_SampleErroring() {
     let (source, sourceObserver) = Signal<Int, SomeError>.pipe()
     let (sample, sampleObserver) = Signal<Int, SomeError>.pipe()
     let withLatestFrom = sample.withLatestFrom(source)
@@ -92,7 +92,7 @@ final class WithLatestFromTests : XCTestCase {
     test.assertDidNotFail()
   }
 
-  func testWithSampleInterrupted() {
+  func testWithLatestFromSignal_SampleInterrupted() {
     let (source, sourceObserver) = Signal<Int, NoError>.pipe()
     let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
     let withLatestFrom = sample.withLatestFrom(source)
@@ -106,4 +106,106 @@ final class WithLatestFromTests : XCTestCase {
     sampleObserver.sendInterrupted()
     test.assertDidNotInterrupt()
   }
+
+  func testWithLatestFromProducer() {
+    let (source, sourceObserver) = SignalProducer<Int, NoError>.buffer(0)
+    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let withLatestFrom = sample.withLatestFrom(source)
+    let test = TestObserver<[Int], NoError>()
+    withLatestFrom.map { [$0, $1] }.observe(test.observer)
+
+    sourceObserver.sendNext(1)
+    test.assertValues([])
+
+    sourceObserver.sendNext(2)
+    test.assertValues([])
+
+    sampleObserver.sendNext(3)
+    test.assertValues([[3, 2]])
+
+    sampleObserver.sendNext(4)
+    test.assertValues([[3, 2], [4, 2]])
+
+    sampleObserver.sendCompleted()
+    test.assertDidNotComplete()
+
+    sourceObserver.sendCompleted()
+    test.assertDidComplete()
+  }
+
+  func testWithLatestFromProducer_SourceCompleting() {
+    let (source, sourceObserver) = SignalProducer<Int, NoError>.buffer(0)
+    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let withLatestFrom = sample.withLatestFrom(source)
+    let test = TestObserver<[Int], NoError>()
+    withLatestFrom.map { [$0, $1] }.observe(test.observer)
+
+    sourceObserver.sendNext(1)
+    sampleObserver.sendNext(3)
+    test.assertValues([[3, 1]])
+
+    sourceObserver.sendCompleted()
+    XCTAssert(test.didComplete)
+  }
+
+  func testWithLatestFromProducer_SourceErroring() {
+    let (source, sourceObserver) = SignalProducer<Int, SomeError>.buffer(0)
+    let (sample, sampleObserver) = Signal<Int, SomeError>.pipe()
+    let withLatestFrom = sample.withLatestFrom(source)
+    let test = TestObserver<[Int], SomeError>()
+    withLatestFrom.map { [$0, $1] }.observe(test.observer)
+
+    sourceObserver.sendNext(1)
+    sampleObserver.sendNext(3)
+    test.assertValues([[3, 1]])
+
+    sourceObserver.sendFailed(SomeError())
+    XCTAssert(test.didFail)
+  }
+
+  func testWithLatestFromProducer_SourceInterrupted() {
+    let (source, sourceObserver) = SignalProducer<Int, NoError>.buffer(0)
+    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let withLatestFrom = sample.withLatestFrom(source)
+    let test = TestObserver<[Int], NoError>()
+    withLatestFrom.map { [$0, $1] }.observe(test.observer)
+
+    sourceObserver.sendNext(1)
+    sampleObserver.sendNext(3)
+    test.assertValues([[3, 1]])
+
+    sourceObserver.sendInterrupted()
+    test.assertDidInterrupt()
+  }
+
+  func testWithLatestFromProducer_SampleErroring() {
+    let (source, sourceObserver) = SignalProducer<Int, SomeError>.buffer(0)
+    let (sample, sampleObserver) = Signal<Int, SomeError>.pipe()
+    let withLatestFrom = sample.withLatestFrom(source)
+    let test = TestObserver<[Int], SomeError>()
+    withLatestFrom.map { [$0, $1] }.observe(test.observer)
+
+    sourceObserver.sendNext(1)
+    sampleObserver.sendNext(3)
+    test.assertValues([[3, 1]])
+
+    sampleObserver.sendFailed(SomeError())
+    test.assertDidNotFail()
+  }
+
+  func testWithLatestFromProducer_SampleInterrupted() {
+    let (source, sourceObserver) = SignalProducer<Int, NoError>.buffer(0)
+    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let withLatestFrom = sample.withLatestFrom(source)
+    let test = TestObserver<[Int], NoError>()
+    withLatestFrom.map { [$0, $1] }.observe(test.observer)
+
+    sourceObserver.sendNext(1)
+    sampleObserver.sendNext(3)
+    test.assertValues([[3, 1]])
+
+    sampleObserver.sendInterrupted()
+    test.assertDidNotInterrupt()
+  }
+
 }


### PR DESCRIPTION
### What

We use the `takeWhen` operators A LOT in our reactive UI work cause it helps us model taking the most recent value of something when a UI action happens, e.g. take login form data when login button is pressed. The backbone of that operator is the one from RxJava called `withLatestFrom`, which is just the flipped version of `takeWhen`, i.e. `a.withLatestFrom(b) == b.takeWhen(a)`. I'm keeping both operators cause sometimes it semantically makes sense to do the flip.

In RAC we have to worry about hot and cold signals explicitly, and so we have to consider the following matrix of possibilities:

``` swift
hot.takeWhen(cold)
cold.takeWhen(hot)
cold.takeWhen(cold)
hot.takeWhen(hot)
```

We have to ask ourselves: do all of these even make sense, and for the ones that do make sense, what should the return type be? Hot or cold?

I gotta say, the only ones that conceptually make sense to me are when we `takeWhen(hot)`, since the whole point of this operator is to take latest values when a UI action (which are hot) occurs. So now we are down to:

``` swift
hot.takeWhen(hot)
cold.takeWhen(hot)
```

So, is the return of those hot or cold? Well, they only emit when the second signal emits, which is hot, so the resulting signal must be hot!

With this insight I've removed the versions that don't make much sense, and added the ones that do.

NB: I do gotta say I'm trying to move us to the world in which everything is hot, so one day I hope to even get rid of `cold.takeWhen(hot)`. Hot signals are the only ones that make sense to me.
