### PR TITLE
Use a mutable property for errors, not an observer.

### DIFF
--- a/ReactiveExtensions/UIKit/UIControl.swift
+++ b/ReactiveExtensions/UIKit/UIControl.swift
@@ -7,8 +7,10 @@ extension UIControl {
     return lazyMutableProperty(
       self,
       key: &AssociationKey.enabled,
-      setter: { self.enabled = $0 },
-      getter: { self.enabled }
-    )
+      setter: {
+        self.enabled = $0 },
+      getter: {
+        self.enabled
+    })
   }
 }

--- a/ReactiveExtensions/operators/DemoteErrors.swift
+++ b/ReactiveExtensions/operators/DemoteErrors.swift
@@ -7,19 +7,19 @@ public extension SignalType {
    inverse of `promoteErrors`.
 
    - parameter value:  An optional value that will be played in place of the error.
-   - parameter errors: An optional observer to send errors to.
+   - parameter errors: An optional property to send errors to.
 
    - returns: A new signal that will never error.
    */
   @warn_unused_result(message="Did you forget to call `observe` on the signal?")
   public func demoteErrors(
     replaceErrorWith value: Value? = nil,
-                     pipeErrorsTo errors: Observer<Error, NoError>? = nil) -> Signal<Value, NoError> {
+                     pipeErrorsTo errors: MutableProperty<Error?>? = nil) -> Signal<Value, NoError> {
 
     return self.signal
       .on(failed: { error in
         if let errors = errors {
-          errors.sendNext(error)
+          errors.value = error
         }
       })
       .flatMapError { error in
@@ -37,14 +37,14 @@ public extension SignalProducerType {
    inverse of `promoteErrors`.
 
    - parameter value:  An optional value that will be played in place of the error.
-   - parameter errors: An optional observer to send errors to.
+   - parameter errors: An optional property to send errors to.
 
    - returns: A new producer that will never error.
    */
   @warn_unused_result(message="Did you forget to call `start` on the producer?")
   public func demoteErrors(
     replaceErrorWith value: Value? = nil,
-                     pipeErrorsTo errors: Observer<Error, NoError>? = nil) -> SignalProducer<Value, NoError> {
+                     pipeErrorsTo errors: MutableProperty<Error?>? = nil) -> SignalProducer<Value, NoError> {
 
     return self.lift { $0.demoteErrors(replaceErrorWith: value, pipeErrorsTo: errors) }
   }

--- a/ReactiveExtensionsTests/operators/DemoteErrorsTests.swift
+++ b/ReactiveExtensionsTests/operators/DemoteErrorsTests.swift
@@ -6,9 +6,10 @@ import Result
 
 final class DemoteErrorTests: XCTestCase {
 
-  func testSignal_DemoteErrorsWithDefaultArgs() {
+  func testDemoteErrors_Signal_WithDefaultArguements() {
     let (signal, observer) = Signal<Int, SomeError>.pipe()
     let testSignal = signal.demoteErrors()
+
     let test = TestObserver<Int, NoError>()
     testSignal.observe(test.observer)
 
@@ -22,16 +23,16 @@ final class DemoteErrorTests: XCTestCase {
     test.assertDidComplete()
   }
 
-  func testSignal_DemoteErrorsWithArgs() {
+  func testDemoteErrors_Signal_WithArguements() {
     let (signal, observer) = Signal<Int, SomeError>.pipe()
-    let (errors, errorObserver) = Signal<SomeError, NoError>.pipe()
-    let testSignal = signal.demoteErrors(replaceErrorWith: 99, pipeErrorsTo: errorObserver)
+    let errors = MutableProperty<SomeError?>(nil)
+    let testSignal = signal.demoteErrors(replaceErrorWith: 99, pipeErrorsTo: errors)
 
     let test = TestObserver<Int, NoError>()
     testSignal.observe(test.observer)
 
-    let errorTest = TestObserver<SomeError, NoError>()
-    errors.observe(errorTest.observer)
+    let errorTest = TestObserver<SomeError?, NoError>()
+    errors.signal.observe(errorTest.observer)
 
     observer.sendNext(1)
     observer.sendNext(2)
@@ -47,9 +48,10 @@ final class DemoteErrorTests: XCTestCase {
     errorTest.assertDidNotFail()
   }
 
-  func testProducer_DemoteErrorsWithDefaultArgs() {
+  func testDemoteErrors_Producer_WithDefaultArguements() {
     let (producer, observer) = SignalProducer<Int, SomeError>.buffer(0)
     let testSignal = producer.demoteErrors()
+
     let test = TestObserver<Int, NoError>()
     testSignal.start(test.observer)
 
@@ -63,16 +65,16 @@ final class DemoteErrorTests: XCTestCase {
     test.assertDidComplete()
   }
 
-  func testProducer_DemoteErrorsWithArgs() {
+  func testDemoteErrors_Producer_WithArguements() {
     let (producer, observer) = SignalProducer<Int, SomeError>.buffer(0)
-    let (errors, errorObserver) = Signal<SomeError, NoError>.pipe()
-    let testSignal = producer.demoteErrors(replaceErrorWith: 99, pipeErrorsTo: errorObserver)
+    let errors = MutableProperty<SomeError?>(nil)
+    let testSignal = producer.demoteErrors(replaceErrorWith: 99, pipeErrorsTo: errors)
 
     let test = TestObserver<Int, NoError>()
     testSignal.start(test.observer)
 
-    let errorTest = TestObserver<SomeError, NoError>()
-    errors.observe(errorTest.observer)
+    let errorTest = TestObserver<SomeError?, NoError>()
+    errors.signal.observe(errorTest.observer)
 
     observer.sendNext(1)
     observer.sendNext(2)


### PR DESCRIPTION
Since we're moving away from long-living signals in favor of mutable properties, this updates our `demoteErrors` operator so that we can pipe errors to a property instead of an observer.
