### PR TITLE
Added a RAC test helper for arrays of optionals of equatables.

### DIFF
--- a/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
+++ b/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
@@ -143,6 +143,29 @@ extension TestObserver where Value: Equatable {
   }
 }
 
+extension TestObserver where Value: ReactiveCocoa.OptionalType, Value.Wrapped: Equatable {
+
+  internal func assertValue(value: Value, _ message: String? = nil,
+                            file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
+    XCTAssertEqual(value.optional, self.lastValue!.optional,
+                   message ?? "A single value of \(value) should have been emitted",
+                   file: file, line: line)
+  }
+
+  internal func assertLastValue(value: Value, _ message: String? = nil,
+                                file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(value.optional, self.lastValue!.optional,
+                   message ?? "Last emitted value is equal to \(value).",
+                   file: file, line: line)
+  }
+
+  internal func assertValues(values: [Value], _ message: String = "",
+                             file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(values, self.values, message, file: file, line: line)
+  }
+}
+
 extension TestObserver where Value: SequenceType, Value.Generator.Element: Equatable {
 
   internal func assertValue(value: Value, _ message: String? = nil,

--- a/ReactiveExtensionsTests/TestHelpers/XCTAssert-Extensions.swift
+++ b/ReactiveExtensionsTests/TestHelpers/XCTAssert-Extensions.swift
@@ -1,4 +1,5 @@
 import XCTest
+import ReactiveCocoa
 
 // Assert equality between two doubly nested arrays of equatables.
 internal func XCTAssertEqual<T: Equatable>(@autoclosure expression1: () -> [[T]],
@@ -13,4 +14,24 @@ internal func XCTAssertEqual<T: Equatable>(@autoclosure expression1: () -> [[T]]
     zip(lhs, rhs).forEach { xs, ys in
       XCTAssertEqual(xs, ys, "Expected \(lhs), but found \(rhs): \(message)", file: file, line: line)
     }
+}
+
+// Assert equality between arrays of optionals of equatables.
+internal func XCTAssertEqual <T: ReactiveCocoa.OptionalType where T.Wrapped: Equatable>
+  (expression1: [T], _ expression2: [T], _ message: String = "",
+   file: StaticString = #file, line: UInt = #line) {
+
+  XCTAssertEqual(
+    expression1.count, expression2.count,
+    "Expected \(expression1.count) elements, but found \(expression2.count).",
+    file: file, line: line
+  )
+
+  zip(expression1, expression2).forEach { xs, ys in
+    XCTAssertEqual(
+      xs.optional, ys.optional,
+      "Expected \(expression1), but found \(expression2): \(message)",
+      file: file, line: line
+    )
+  }
 }


### PR DESCRIPTION
### What

Adds a new version of `XCTAssertEqual` and `test.assertValues` that works on `Array<Optional<Equatable>>`... Swift 3's full generics can't come any sooner.

@luoser ran into this yesterday while trying to write a test that asserted on a signal that had optional values, and I just ran into it.
