### PR TITLE
Speed up compilation of slidingWindow by more than 1 second.

### DIFF
--- a/ReactiveExtensions/operators/SlidingWindow.swift
+++ b/ReactiveExtensions/operators/SlidingWindow.swift
@@ -16,7 +16,7 @@ public extension SignalType {
       .scan([Value]()) { window, value in
 
         if window.count >= max {
-          return Array(window[1..<window.count]) + [value]
+          return Array<Value>(window[1..<window.count]) + [value]
         }
         return window + [value]
 


### PR DESCRIPTION
I finally got the BuildTimeAnalyzer Xcode plugin working and saw that our `slidingWindow` operator was taking 1.5 seconds to compile. It's pretty well known that the swift compiler has trouble inferring types when it comes to concatenation of arrays. For example, something as simple as `let xs = [1] + [] + [] + [] + []` cannot be figured out in a reasonable amount of time.

So, I helped out the type checker and brought the time down to ~50ms. I'll be keeping an eye on things like this and hopefully it helps us out in the future. Also hopefully things like this aren't necessary in the future.
