### PR TITLE
Add becomeFirstResponder rac extension

### DIFF
--- a/ReactiveExtensions/LazyMutableProperty.swift
+++ b/ReactiveExtensions/LazyMutableProperty.swift
@@ -15,7 +15,7 @@ public func lazyMutableProperty<T>(host: AnyObject, key: UnsafePointer<Void>, se
                                   getter: () -> T) -> MutableProperty<T> {
   return lazyAssociatedProperty(host, key: key) {
     let property = MutableProperty<T>(getter())
-    property.producer.startWithNext { value in
+    property.producer.skip(1).startWithNext { value in
       setter(value)
     }
     return property

--- a/ReactiveExtensions/UIKit/UIResponder.swift
+++ b/ReactiveExtensions/UIKit/UIResponder.swift
@@ -3,10 +3,29 @@ import Result
 import UIKit
 
 private enum Associations {
-  private static var firstResponder = 0
+  private static var becomeFirstResponder = 0
+  private static var firstResponder = 1
 }
 
 public extension Rac where Object: UIResponder {
+  public var becomeFirstResponder: Signal<(), NoError> {
+    nonmutating set {
+      let prop: MutableProperty<()> = lazyMutableProperty(
+        object,
+        key: &Associations.becomeFirstResponder,
+        setter: { [weak object] in
+          object?.becomeFirstResponder()
+        },
+        getter: { () })
+
+      prop <~ newValue.observeForUI()
+    }
+
+    get {
+      return .empty
+    }
+  }
+
   public var isFirstResponder: Signal<Bool, NoError> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(

--- a/ReactiveExtensionsTests/UIKit/UIResponderTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIResponderTests.swift
@@ -18,10 +18,22 @@ final class UIResponderTests: XCTestCase {
     self.window.addSubview(self.responder)
   }
 
+  func testBecomeFirstResponder() {
+    let (signal, observer) = Signal<(), NoError>.pipe()
+    responder.rac.becomeFirstResponder = signal
+
+    eventually(XCTAssertFalse(self.responder.isFirstResponder()))
+
+    observer.sendNext()
+    eventually(XCTAssertTrue(self.responder.isFirstResponder()))
+  }
+
   func testIsFirstResponder() {
 
     let (signal, observer) = Signal<Bool, NoError>.pipe()
     responder.rac.isFirstResponder = signal
+
+    eventually(XCTAssertFalse(self.responder.isFirstResponder()))
 
     observer.sendNext(true)
     eventually(XCTAssertTrue(self.responder.isFirstResponder()))


### PR DESCRIPTION
### WHAT

Add a rac extension to trigger a `becomeFirstResponder` call on a UI element. This is slightly different to `isFirstResponder`; that extension is a boolean signal that allows a UI element to resign from being first responder.

Example usage:

``` swift
// Output in view model:
var myTextFieldBecomeFirstResponder: Signal<(), NoError> { get }

// Bind in view controller:
self.myTextField.rac.becomeFirstResponder = self.viewModel.outputs.myTextFieldBecomeFirstResponder
```
