### PR TITLE
Add an observe method just for controllers.

### DIFF
--- a/ReactiveExtensions/operators/ObserveForUI.swift
+++ b/ReactiveExtensions/operators/ObserveForUI.swift
@@ -11,6 +11,18 @@ public extension SignalType {
   public func observeForUI() -> Signal<Value, Error> {
     return self.signal.observeOn(UIScheduler())
   }
+
+  /**
+   Transforms the signal into one that can perform actions for a controller. Use this operator when doing
+   any side-effects from a controller. We've found that `UIScheduler` can be problematic with many
+   controller actions, such as presenting and dismissing of view controllers.
+
+   - returns: A new signal.
+   */
+  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  public func observeForControllerAction() -> Signal<Value, Error> {
+    return self.signal.observeOn(QueueScheduler.mainQueueScheduler)
+  }
 }
 
 public extension SignalProducerType {


### PR DESCRIPTION
### What

Have you noticed how sometimes you have to tap twice to open a project, or that there is a noticeable delay in certain UI actions? Well, I'm not sure precisely why it is happening, but I do have a fix.

Right now our `observeForUI()` schedules work on the `UIScheduler` scheduler, which will perform the action immediately if we are on the main queue, and otherwise dispatch it async to the main queue. This is great for cells because they need to perform their layout as quickly as possible so that we can take advantage of auto-sizing cells (remember the days of needing to tell table views how big each cell was?!).

However, controllers seem to have a problem with this. Especially when the UI action being performed is to present/dismiss/push a view controller. I've found that those actions come with a significant delay when using `UIScheduler`. Dispatching the work onto the next runloop of the main queue seemed to fix it for some reason. Luckily, there's an easy way to do that: `observeOn(QueueScheduler.mainQueueScheduler)`. I've packaged this into its own operator is that it will be clearer that this is the thing to use when observing signals in a controller.

I have another PR coming where I update all of our controllers with this new operator.
