### PR TITLE
Swift 2.3 upgrade

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 8.0
+    version: 7.3
 dependencies:
   pre:
     - brew update || brew update


### PR DESCRIPTION
ReactiveExtensions doesn't need any actual code upgrade, just an upgrade to the project file saying what version of swift to use.
