### PR TITLE
Change to optimization settings.

### DIFF
--- a/ReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ReactiveExtensions.xcodeproj/project.pbxproj
@@ -1513,9 +1513,11 @@
 				INFOPLIST_FILE = ReactiveExtensions/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -debug-time-function-bodies -Onone";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.ReactiveExtensions;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};


### PR DESCRIPTION
Found this time http://stackoverflow.com/questions/25537614/why-is-swift-compile-time-so-slow/40370475#40370475 on stackoverflow, and was able to cut 60 seconds off a fresh build on the whole app. Gonna apply this to all of our repos...