### PR TITLE
Swift 3 compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Frameworks/ReactiveCocoa"]
 	path = Frameworks/ReactiveCocoa
 	url = git://github.com/ReactiveCocoa/ReactiveCocoa.git
+[submodule "Frameworks/ReactiveSwift"]
+	path = Frameworks/ReactiveSwift
+	url = https://github.com/ReactiveCocoa/ReactiveSwift

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Frameworks/ReactiveCocoa"]
-	path = Frameworks/ReactiveCocoa
-	url = git://github.com/ReactiveCocoa/ReactiveCocoa.git
 [submodule "Frameworks/ReactiveSwift"]
 	path = Frameworks/ReactiveSwift
 	url = https://github.com/ReactiveCocoa/ReactiveSwift

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Circle CI](https://circleci.com/gh/kickstarter/Kickstarter-ReactiveExtensions.svg?style=svg&circle-token=87cb6246722fd8b503516bcdcf84e64256f86470)](https://circleci.com/gh/kickstarter/Kickstarter-ReactiveExtensions)
 
-A collection of extensions to the [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa) framework.
+A collection of extensions to the [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift) framework.

--- a/ReactiveExtensions.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
+++ b/ReactiveExtensions.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
@@ -54,7 +54,7 @@ import Result
  optional values, and then immediately follow it with an `ignoreNil` in order to filter out
  all `nil` values:
 
- user.map { u in u.location }.ignoreNil()
+ user.map { u in u.location }.skipNil()
 
  We decided to make these two chained operators into a single one, simply called `flatMap`:
 

--- a/ReactiveExtensions.playground/contents.xcplayground
+++ b/ReactiveExtensions.playground/contents.xcplayground
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw' executeOnSourceChanges='false'/>
+<playground version='6.0' target-platform='ios' display-mode='raw' executeOnSourceChanges='false' last-migration='0820'/>

--- a/ReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ReactiveExtensions.xcodeproj/project.pbxproj
@@ -15,8 +15,6 @@
 		803BDFA91D11B364004A785A /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BDFA71D11B364004A785A /* UITextField.swift */; };
 		803BDFB61D11B391004A785A /* UITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BDFB51D11B391004A785A /* UITextFieldTests.swift */; };
 		803BDFB71D11B391004A785A /* UITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BDFB51D11B391004A785A /* UITextFieldTests.swift */; };
-		807571471C88B20300E7DA8A /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 807571231C88B1C500E7DA8A /* ReactiveCocoa.framework */; };
-		8075714A1C88B20F00E7DA8A /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 807571291C88B1C500E7DA8A /* ReactiveCocoa.framework */; };
 		8096F28C1CC91C1500231D91 /* Rac.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096F28B1CC91C1500231D91 /* Rac.swift */; };
 		8096F2991CC92A4D00231D91 /* Rac.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096F28B1CC91C1500231D91 /* Rac.swift */; };
 		8096F29F1CC92AA700231D91 /* UIControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096F29E1CC92AA700231D91 /* UIControlTests.swift */; };
@@ -25,8 +23,6 @@
 		8096F2A31CC92AAF00231D91 /* UILabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096F2A11CC92AAF00231D91 /* UILabelTests.swift */; };
 		8096F2A51CC92AB600231D91 /* UIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096F2A41CC92AB600231D91 /* UIViewTests.swift */; };
 		8096F2A61CC92AB600231D91 /* UIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096F2A41CC92AB600231D91 /* UIViewTests.swift */; };
-		A709699E1D146B0500DB39D3 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8075713A1C88B1E100E7DA8A /* Result.framework */; };
-		A70969B81D147BA000DB39D3 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8075713E1C88B1E100E7DA8A /* Result.framework */; };
 		A713EC791C2B55EB00B6234E /* SlidingWindowTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A713EC781C2B55EB00B6234E /* SlidingWindowTest.swift */; };
 		A713EC7D1C2B82FF00B6234E /* MapConstTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A713EC7C1C2B82FF00B6234E /* MapConstTests.swift */; };
 		A713EC7F1C2B83FF00B6234E /* DebounceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A713EC7E1C2B83FF00B6234E /* DebounceTests.swift */; };
@@ -43,8 +39,6 @@
 		A72942A91DE2459000BB3455 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72942A71DE2459000BB3455 /* Enumerated.swift */; };
 		A72942B61DE2463400BB3455 /* EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72942B51DE2463400BB3455 /* EnumeratedTests.swift */; };
 		A72942B71DE2463400BB3455 /* EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72942B51DE2463400BB3455 /* EnumeratedTests.swift */; };
-		A72A50651D00A91100894A36 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8075713A1C88B1E100E7DA8A /* Result.framework */; };
-		A72A508F1D00B0FA00894A36 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8075713E1C88B1E100E7DA8A /* Result.framework */; };
 		A72E75281CC1849100983066 /* Values.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72E75271CC1849100983066 /* Values.swift */; };
 		A72E75291CC1849100983066 /* Values.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72E75271CC1849100983066 /* Values.swift */; };
 		A72E75371CC1849B00983066 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72E75361CC1849B00983066 /* Errors.swift */; };
@@ -99,6 +93,14 @@
 		A7983B5F1C2AF8B0003A1ABE /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7983B5E1C2AF8B0003A1ABE /* UILabel.swift */; };
 		A7983B631C2AF8D4003A1ABE /* UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7983B621C2AF8D4003A1ABE /* UIControl.swift */; };
 		A7983B8D1C2AFB1D003A1ABE /* ReactiveExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43C6631BB35FCF00C180DA /* ReactiveExtensions.framework */; };
+		A79BE79C1E0709990077A9B2 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE77A1E07091D0077A9B2 /* Result.framework */; };
+		A79BE79D1E07099D0077A9B2 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE75B1E0709020077A9B2 /* ReactiveSwift.framework */; };
+		A79BE7A61E070E700077A9B2 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE75B1E0709020077A9B2 /* ReactiveSwift.framework */; };
+		A79BE7A71E070E740077A9B2 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE77A1E07091D0077A9B2 /* Result.framework */; };
+		A79BE7AA1E0711500077A9B2 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE7611E0709020077A9B2 /* ReactiveSwift.framework */; };
+		A79BE7AD1E0711570077A9B2 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE77E1E07091D0077A9B2 /* Result.framework */; };
+		A79BE7B21E0711650077A9B2 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE7611E0709020077A9B2 /* ReactiveSwift.framework */; };
+		A79BE7B31E0711690077A9B2 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE77E1E07091D0077A9B2 /* Result.framework */; };
 		A7A015D71CBDA99100C4B821 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A015D61CBDA99100C4B821 /* TakeUntil.swift */; };
 		A7A015D81CBDA99100C4B821 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A015D61CBDA99100C4B821 /* TakeUntil.swift */; };
 		A7B11A561D78A43D00A5036E /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B11A551D78A43D00A5036E /* Scan.swift */; };
@@ -133,8 +135,6 @@
 		A7DB1D511C9F4FD7008244DA /* XCTAssert-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DB1D4A1C9F4EE9008244DA /* XCTAssert-Extensions.swift */; };
 		A7DB1D521C9F4FD7008244DA /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DB1D321C9F30AE008244DA /* TestObserver.swift */; };
 		A7DB1D5E1C9F500D008244DA /* ReactiveExtensions_TestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7DB1D5A1C9F4FD7008244DA /* ReactiveExtensions_TestHelpers.framework */; };
-		A7DB1D611C9F5125008244DA /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 807571291C88B1C500E7DA8A /* ReactiveCocoa.framework */; };
-		A7DB1D641C9F5135008244DA /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 807571231C88B1C500E7DA8A /* ReactiveCocoa.framework */; };
 		A7F3C6641CFF4DBA005DBE95 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F3C6631CFF4DBA005DBE95 /* UIButtonTests.swift */; };
 		A7F3C6651CFF4DBA005DBE95 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F3C6631CFF4DBA005DBE95 /* UIButtonTests.swift */; };
 		A7FD08891C81EDBD00332CCB /* MergeWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510611C27371E00C59136 /* MergeWith.swift */; };
@@ -178,152 +178,173 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		8075711E1C88B1C500E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D04725EA19E49ED7006002AA;
-			remoteInfo = "ReactiveCocoa-Mac";
-		};
-		807571201C88B1C500E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D04725F519E49ED7006002AA;
-			remoteInfo = "ReactiveCocoa-MacTests";
-		};
-		807571221C88B1C500E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D047260C19E49F82006002AA;
-			remoteInfo = "ReactiveCocoa-iOS";
-		};
-		807571241C88B1C500E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D047261619E49F82006002AA;
-			remoteInfo = "ReactiveCocoa-iOSTests";
-		};
-		807571261C88B1C500E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = A9B315541B3940610001CB9C;
-			remoteInfo = "ReactiveCocoa-watchOS";
-		};
-		807571281C88B1C500E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 57A4D2411BA13D7A00F7D4B1;
-			remoteInfo = "ReactiveCocoa-tvOS";
-		};
-		807571351C88B1E100E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D45480571A9572F5009D7229;
-			remoteInfo = "Result-Mac";
-		};
-		807571371C88B1E100E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D45480671A9572F5009D7229;
-			remoteInfo = "Result-MacTests";
-		};
-		807571391C88B1E100E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D454807D1A957361009D7229;
-			remoteInfo = "Result-iOS";
-		};
-		8075713B1C88B1E100E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D45480871A957362009D7229;
-			remoteInfo = "Result-iOSTests";
-		};
-		8075713D1C88B1E100E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 57FCDE471BA280DC00130C48;
-			remoteInfo = "Result-tvOS";
-		};
-		8075713F1C88B1E100E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 57FCDE541BA280E000130C48;
-			remoteInfo = "Result-tvOSTests";
-		};
-		807571411C88B1E100E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D03579A31B2B788F005D26AE;
-			remoteInfo = "Result-watchOS";
-		};
-		807571431C88B1E100E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D03579B01B2B78A1005D26AE;
-			remoteInfo = "Result-watchOSTests";
-		};
-		807571451C88B1FC00E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D047260B19E49F82006002AA;
-			remoteInfo = "ReactiveCocoa-iOS";
-		};
-		807571481C88B20C00E7DA8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 57A4D1AF1BA13D7A00F7D4B1;
-			remoteInfo = "ReactiveCocoa-tvOS";
-		};
-		A70969911D146AFC00DB39D3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D454807C1A957361009D7229;
-			remoteInfo = "Result-iOS";
-		};
-		A70969B61D147B9A00DB39D3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 57FCDE3C1BA280DC00130C48;
-			remoteInfo = "Result-tvOS";
-		};
-		A72A50571D00A90900894A36 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D454807C1A957361009D7229;
-			remoteInfo = "Result-iOS";
-		};
-		A72A508D1D00B0F300894A36 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 57FCDE3C1BA280DC00130C48;
-			remoteInfo = "Result-tvOS";
-		};
 		A7983B8E1C2AFB1D003A1ABE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CA43C65A1BB35FCF00C180DA /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = CA43C6621BB35FCF00C180DA;
 			remoteInfo = ReactiveExtensions;
+		};
+		A79BE7561E0709020077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D04725EA19E49ED7006002AA;
+			remoteInfo = "ReactiveSwift-macOS";
+		};
+		A79BE7581E0709020077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D04725F519E49ED7006002AA;
+			remoteInfo = "ReactiveSwift-macOSTests";
+		};
+		A79BE75A1E0709020077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D047260C19E49F82006002AA;
+			remoteInfo = "ReactiveSwift-iOS";
+		};
+		A79BE75C1E0709020077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D047261619E49F82006002AA;
+			remoteInfo = "ReactiveSwift-iOSTests";
+		};
+		A79BE75E1E0709020077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A9B315541B3940610001CB9C;
+			remoteInfo = "ReactiveSwift-watchOS";
+		};
+		A79BE7601E0709020077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 57A4D2411BA13D7A00F7D4B1;
+			remoteInfo = "ReactiveSwift-tvOS";
+		};
+		A79BE7621E0709020077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7DFBED031CDB8C9500EE435B;
+			remoteInfo = "ReactiveSwift-tvOSTests";
+		};
+		A79BE7751E07091D0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D45480571A9572F5009D7229;
+			remoteInfo = "Result-Mac";
+		};
+		A79BE7771E07091D0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D45480671A9572F5009D7229;
+			remoteInfo = "Result-MacTests";
+		};
+		A79BE7791E07091D0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D454807D1A957361009D7229;
+			remoteInfo = "Result-iOS";
+		};
+		A79BE77B1E07091D0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D45480871A957362009D7229;
+			remoteInfo = "Result-iOSTests";
+		};
+		A79BE77D1E07091D0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 57FCDE471BA280DC00130C48;
+			remoteInfo = "Result-tvOS";
+		};
+		A79BE77F1E07091D0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 57FCDE541BA280E000130C48;
+			remoteInfo = "Result-tvOSTests";
+		};
+		A79BE7811E07091D0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D03579A31B2B788F005D26AE;
+			remoteInfo = "Result-watchOS";
+		};
+		A79BE7831E07091D0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D03579B01B2B78A1005D26AE;
+			remoteInfo = "Result-watchOSTests";
+		};
+		A79BE7891E0709900077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = D047260B19E49F82006002AA;
+			remoteInfo = "ReactiveSwift-iOS";
+		};
+		A79BE79A1E0709940077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = D454807C1A957361009D7229;
+			remoteInfo = "Result-iOS";
+		};
+		A79BE7A21E070E670077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = D047260B19E49F82006002AA;
+			remoteInfo = "ReactiveSwift-iOS";
+		};
+		A79BE7A41E070E6B0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = D454807C1A957361009D7229;
+			remoteInfo = "Result-iOS";
+		};
+		A79BE7A81E07114A0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 57A4D1AF1BA13D7A00F7D4B1;
+			remoteInfo = "ReactiveSwift-tvOS";
+		};
+		A79BE7AB1E0711530077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 57FCDE3C1BA280DC00130C48;
+			remoteInfo = "Result-tvOS";
+		};
+		A79BE7AE1E07115E0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 57A4D1AF1BA13D7A00F7D4B1;
+			remoteInfo = "ReactiveSwift-tvOS";
+		};
+		A79BE7B01E0711610077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 57FCDE3C1BA280DC00130C48;
+			remoteInfo = "Result-tvOS";
 		};
 		A7DB1D441C9F4E3F008244DA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -339,27 +360,6 @@
 			remoteGlobalIDString = A7DB1D4C1C9F4FD7008244DA;
 			remoteInfo = "ReactiveExtensions-TestHelpers-tvOS";
 		};
-		A7DB1D5F1C9F511D008244DA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 57A4D1AF1BA13D7A00F7D4B1;
-			remoteInfo = "ReactiveCocoa-tvOS";
-		};
-		A7DB1D621C9F512B008244DA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D047260B19E49F82006002AA;
-			remoteInfo = "ReactiveCocoa-iOS";
-		};
-		A7F440CA1CFFDCE200FE6FC5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 7DFBED031CDB8C9500EE435B;
-			remoteInfo = "ReactiveCocoa-tvOSTests";
-		};
 		A7FD09DA1C84902100332CCB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CA43C65A1BB35FCF00C180DA /* Project object */;
@@ -374,8 +374,6 @@
 		59DB70551D00DC9B00BCE6A9 /* UISwitchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISwitchTests.swift; sourceTree = "<group>"; };
 		803BDFA71D11B364004A785A /* UITextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextField.swift; sourceTree = "<group>"; };
 		803BDFB51D11B391004A785A /* UITextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextFieldTests.swift; sourceTree = "<group>"; };
-		807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReactiveCocoa.xcodeproj; path = Frameworks/ReactiveCocoa/ReactiveCocoa.xcodeproj; sourceTree = "<group>"; };
-		8075712A1C88B1E000E7DA8A /* Result.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Result.xcodeproj; path = Frameworks/ReactiveCocoa/Carthage/Checkouts/Result/Result.xcodeproj; sourceTree = "<group>"; };
 		8096F28B1CC91C1500231D91 /* Rac.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Rac.swift; sourceTree = "<group>"; };
 		8096F29E1CC92AA700231D91 /* UIControlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControlTests.swift; sourceTree = "<group>"; };
 		8096F2A11CC92AAF00231D91 /* UILabelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabelTests.swift; sourceTree = "<group>"; };
@@ -425,6 +423,8 @@
 		A7983B5E1C2AF8B0003A1ABE /* UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
 		A7983B621C2AF8D4003A1ABE /* UIControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControl.swift; sourceTree = "<group>"; };
 		A7983B881C2AFB1C003A1ABE /* ReactiveExtensions-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReactiveExtensions-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReactiveSwift.xcodeproj; path = Frameworks/ReactiveSwift/ReactiveSwift.xcodeproj; sourceTree = "<group>"; };
+		A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Result.xcodeproj; path = Frameworks/ReactiveSwift/Carthage/Checkouts/Result/Result.xcodeproj; sourceTree = "<group>"; };
 		A7A015D61CBDA99100C4B821 /* TakeUntil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TakeUntil.swift; sourceTree = "<group>"; };
 		A7B11A551D78A43D00A5036E /* Scan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scan.swift; sourceTree = "<group>"; };
 		A7B11A631D78A4C100A5036E /* ScanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanTests.swift; sourceTree = "<group>"; };
@@ -475,8 +475,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A7DB1D641C9F5135008244DA /* ReactiveCocoa.framework in Frameworks */,
-				A709699E1D146B0500DB39D3 /* Result.framework in Frameworks */,
+				A79BE7A71E070E740077A9B2 /* Result.framework in Frameworks */,
+				A79BE7A61E070E700077A9B2 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -484,8 +484,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A7DB1D611C9F5125008244DA /* ReactiveCocoa.framework in Frameworks */,
-				A70969B81D147BA000DB39D3 /* Result.framework in Frameworks */,
+				A79BE7B31E0711690077A9B2 /* Result.framework in Frameworks */,
+				A79BE7B21E0711650077A9B2 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -493,8 +493,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				807571471C88B20300E7DA8A /* ReactiveCocoa.framework in Frameworks */,
-				A72A50651D00A91100894A36 /* Result.framework in Frameworks */,
+				A79BE79D1E07099D0077A9B2 /* ReactiveSwift.framework in Frameworks */,
+				A79BE79C1E0709990077A9B2 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -511,43 +511,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8075714A1C88B20F00E7DA8A /* ReactiveCocoa.framework in Frameworks */,
-				A72A508F1D00B0FA00894A36 /* Result.framework in Frameworks */,
+				A79BE7AD1E0711570077A9B2 /* Result.framework in Frameworks */,
+				A79BE7AA1E0711500077A9B2 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		807571161C88B1C500E7DA8A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				8075711F1C88B1C500E7DA8A /* ReactiveCocoa.framework */,
-				807571211C88B1C500E7DA8A /* ReactiveCocoaTests.xctest */,
-				807571231C88B1C500E7DA8A /* ReactiveCocoa.framework */,
-				807571251C88B1C500E7DA8A /* ReactiveCocoaTests.xctest */,
-				807571271C88B1C500E7DA8A /* ReactiveCocoa.framework */,
-				807571291C88B1C500E7DA8A /* ReactiveCocoa.framework */,
-				A7F440CB1CFFDCE200FE6FC5 /* ReactiveCocoaTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		8075712B1C88B1E000E7DA8A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				807571361C88B1E100E7DA8A /* Result.framework */,
-				807571381C88B1E100E7DA8A /* Result-MacTests.xctest */,
-				8075713A1C88B1E100E7DA8A /* Result.framework */,
-				8075713C1C88B1E100E7DA8A /* Result-iOSTests.xctest */,
-				8075713E1C88B1E100E7DA8A /* Result.framework */,
-				807571401C88B1E100E7DA8A /* Result-tvOSTests.xctest */,
-				807571421C88B1E100E7DA8A /* Result.framework */,
-				807571441C88B1E100E7DA8A /* Result-watchOSTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		8096F29A1CC92A6300231D91 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
@@ -625,6 +596,35 @@
 			path = UIKit;
 			sourceTree = "<group>";
 		};
+		A79BE7481E0709020077A9B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A79BE7571E0709020077A9B2 /* ReactiveSwift.framework */,
+				A79BE7591E0709020077A9B2 /* ReactiveSwiftTests.xctest */,
+				A79BE75B1E0709020077A9B2 /* ReactiveSwift.framework */,
+				A79BE75D1E0709020077A9B2 /* ReactiveSwiftTests.xctest */,
+				A79BE75F1E0709020077A9B2 /* ReactiveSwift.framework */,
+				A79BE7611E0709020077A9B2 /* ReactiveSwift.framework */,
+				A79BE7631E0709020077A9B2 /* ReactiveSwiftTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A79BE76B1E07091D0077A9B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A79BE7761E07091D0077A9B2 /* Result.framework */,
+				A79BE7781E07091D0077A9B2 /* Result-MacTests.xctest */,
+				A79BE77A1E07091D0077A9B2 /* Result.framework */,
+				A79BE77C1E07091D0077A9B2 /* Result-iOSTests.xctest */,
+				A79BE77E1E07091D0077A9B2 /* Result.framework */,
+				A79BE7801E07091D0077A9B2 /* Result-tvOSTests.xctest */,
+				A79BE7821E07091D0077A9B2 /* Result.framework */,
+				A79BE7841E07091D0077A9B2 /* Result-watchOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		A7BF76BB1C554EF4003D0881 /* lib */ = {
 			isa = PBXGroup;
 			children = (
@@ -680,8 +680,8 @@
 		A7FD087F1C81ED5D00332CCB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */,
-				8075712A1C88B1E000E7DA8A /* Result.xcodeproj */,
+				A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */,
+				A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -793,8 +793,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				A7DB1D631C9F512B008244DA /* PBXTargetDependency */,
-				A70969921D146AFC00DB39D3 /* PBXTargetDependency */,
+				A79BE7A51E070E6B0077A9B2 /* PBXTargetDependency */,
+				A79BE7A31E070E670077A9B2 /* PBXTargetDependency */,
 			);
 			name = "ReactiveExtensions-TestHelpers-iOS";
 			productName = ReactiveExtensions_TestHelpers;
@@ -813,8 +813,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				A7DB1D601C9F511D008244DA /* PBXTargetDependency */,
-				A70969B71D147B9A00DB39D3 /* PBXTargetDependency */,
+				A79BE7B11E0711610077A9B2 /* PBXTargetDependency */,
+				A79BE7AF1E07115E0077A9B2 /* PBXTargetDependency */,
 			);
 			name = "ReactiveExtensions-TestHelpers-tvOS";
 			productName = ReactiveExtensions_TestHelpers;
@@ -833,8 +833,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				807571461C88B1FC00E7DA8A /* PBXTargetDependency */,
-				A72A50581D00A90900894A36 /* PBXTargetDependency */,
+				A79BE79B1E0709940077A9B2 /* PBXTargetDependency */,
+				A79BE78A1E0709900077A9B2 /* PBXTargetDependency */,
 			);
 			name = "ReactiveExtensions-iOS";
 			productName = ReactiveExtensions;
@@ -872,8 +872,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				807571491C88B20C00E7DA8A /* PBXTargetDependency */,
-				A72A508E1D00B0F300894A36 /* PBXTargetDependency */,
+				A79BE7AC1E0711530077A9B2 /* PBXTargetDependency */,
+				A79BE7A91E07114A0077A9B2 /* PBXTargetDependency */,
 			);
 			name = "ReactiveExtensions-tvOS";
 			productName = ReactiveExtensions;
@@ -887,7 +887,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Kickstarter;
 				TargetAttributes = {
 					A7983B871C2AFB1C003A1ABE = {
@@ -896,16 +896,16 @@
 					};
 					A7DB1D391C9F355E008244DA = {
 						CreatedOnToolsVersion = 7.2.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 					};
 					A7DB1D4C1C9F4FD7008244DA = {
 						LastSwiftMigration = 0800;
 					};
 					A7FD08861C81EDBD00332CCB = {
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 					};
 					A7FD08BE1C81EEA100332CCB = {
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 					};
 					CA43C6621BB35FCF00C180DA = {
 						CreatedOnToolsVersion = 7.1;
@@ -925,12 +925,12 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 807571161C88B1C500E7DA8A /* Products */;
-					ProjectRef = 807571151C88B1C500E7DA8A /* ReactiveCocoa.xcodeproj */;
+					ProductGroup = A79BE7481E0709020077A9B2 /* Products */;
+					ProjectRef = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
 				},
 				{
-					ProductGroup = 8075712B1C88B1E000E7DA8A /* Products */;
-					ProjectRef = 8075712A1C88B1E000E7DA8A /* Result.xcodeproj */;
+					ProductGroup = A79BE76B1E07091D0077A9B2 /* Products */;
+					ProjectRef = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -946,109 +946,109 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		8075711F1C88B1C500E7DA8A /* ReactiveCocoa.framework */ = {
+		A79BE7571E0709020077A9B2 /* ReactiveSwift.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
-			path = ReactiveCocoa.framework;
-			remoteRef = 8075711E1C88B1C500E7DA8A /* PBXContainerItemProxy */;
+			path = ReactiveSwift.framework;
+			remoteRef = A79BE7561E0709020077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571211C88B1C500E7DA8A /* ReactiveCocoaTests.xctest */ = {
+		A79BE7591E0709020077A9B2 /* ReactiveSwiftTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = ReactiveCocoaTests.xctest;
-			remoteRef = 807571201C88B1C500E7DA8A /* PBXContainerItemProxy */;
+			path = ReactiveSwiftTests.xctest;
+			remoteRef = A79BE7581E0709020077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571231C88B1C500E7DA8A /* ReactiveCocoa.framework */ = {
+		A79BE75B1E0709020077A9B2 /* ReactiveSwift.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
-			path = ReactiveCocoa.framework;
-			remoteRef = 807571221C88B1C500E7DA8A /* PBXContainerItemProxy */;
+			path = ReactiveSwift.framework;
+			remoteRef = A79BE75A1E0709020077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571251C88B1C500E7DA8A /* ReactiveCocoaTests.xctest */ = {
+		A79BE75D1E0709020077A9B2 /* ReactiveSwiftTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = ReactiveCocoaTests.xctest;
-			remoteRef = 807571241C88B1C500E7DA8A /* PBXContainerItemProxy */;
+			path = ReactiveSwiftTests.xctest;
+			remoteRef = A79BE75C1E0709020077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571271C88B1C500E7DA8A /* ReactiveCocoa.framework */ = {
+		A79BE75F1E0709020077A9B2 /* ReactiveSwift.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
-			path = ReactiveCocoa.framework;
-			remoteRef = 807571261C88B1C500E7DA8A /* PBXContainerItemProxy */;
+			path = ReactiveSwift.framework;
+			remoteRef = A79BE75E1E0709020077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571291C88B1C500E7DA8A /* ReactiveCocoa.framework */ = {
+		A79BE7611E0709020077A9B2 /* ReactiveSwift.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
-			path = ReactiveCocoa.framework;
-			remoteRef = 807571281C88B1C500E7DA8A /* PBXContainerItemProxy */;
+			path = ReactiveSwift.framework;
+			remoteRef = A79BE7601E0709020077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571361C88B1E100E7DA8A /* Result.framework */ = {
+		A79BE7631E0709020077A9B2 /* ReactiveSwiftTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ReactiveSwiftTests.xctest;
+			remoteRef = A79BE7621E0709020077A9B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A79BE7761E07091D0077A9B2 /* Result.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = Result.framework;
-			remoteRef = 807571351C88B1E100E7DA8A /* PBXContainerItemProxy */;
+			remoteRef = A79BE7751E07091D0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571381C88B1E100E7DA8A /* Result-MacTests.xctest */ = {
+		A79BE7781E07091D0077A9B2 /* Result-MacTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "Result-MacTests.xctest";
-			remoteRef = 807571371C88B1E100E7DA8A /* PBXContainerItemProxy */;
+			remoteRef = A79BE7771E07091D0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		8075713A1C88B1E100E7DA8A /* Result.framework */ = {
+		A79BE77A1E07091D0077A9B2 /* Result.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = Result.framework;
-			remoteRef = 807571391C88B1E100E7DA8A /* PBXContainerItemProxy */;
+			remoteRef = A79BE7791E07091D0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		8075713C1C88B1E100E7DA8A /* Result-iOSTests.xctest */ = {
+		A79BE77C1E07091D0077A9B2 /* Result-iOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "Result-iOSTests.xctest";
-			remoteRef = 8075713B1C88B1E100E7DA8A /* PBXContainerItemProxy */;
+			remoteRef = A79BE77B1E07091D0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		8075713E1C88B1E100E7DA8A /* Result.framework */ = {
+		A79BE77E1E07091D0077A9B2 /* Result.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = Result.framework;
-			remoteRef = 8075713D1C88B1E100E7DA8A /* PBXContainerItemProxy */;
+			remoteRef = A79BE77D1E07091D0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571401C88B1E100E7DA8A /* Result-tvOSTests.xctest */ = {
+		A79BE7801E07091D0077A9B2 /* Result-tvOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "Result-tvOSTests.xctest";
-			remoteRef = 8075713F1C88B1E100E7DA8A /* PBXContainerItemProxy */;
+			remoteRef = A79BE77F1E07091D0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571421C88B1E100E7DA8A /* Result.framework */ = {
+		A79BE7821E07091D0077A9B2 /* Result.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = Result.framework;
-			remoteRef = 807571411C88B1E100E7DA8A /* PBXContainerItemProxy */;
+			remoteRef = A79BE7811E07091D0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		807571441C88B1E100E7DA8A /* Result-watchOSTests.xctest */ = {
+		A79BE7841E07091D0077A9B2 /* Result-watchOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "Result-watchOSTests.xctest";
-			remoteRef = 807571431C88B1E100E7DA8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A7F440CB1CFFDCE200FE6FC5 /* ReactiveCocoaTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = ReactiveCocoaTests.xctest;
-			remoteRef = A7F440CA1CFFDCE200FE6FC5 /* PBXContainerItemProxy */;
+			remoteRef = A79BE7831E07091D0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -1298,40 +1298,50 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		807571461C88B1FC00E7DA8A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ReactiveCocoa-iOS";
-			targetProxy = 807571451C88B1FC00E7DA8A /* PBXContainerItemProxy */;
-		};
-		807571491C88B20C00E7DA8A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ReactiveCocoa-tvOS";
-			targetProxy = 807571481C88B20C00E7DA8A /* PBXContainerItemProxy */;
-		};
-		A70969921D146AFC00DB39D3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Result-iOS";
-			targetProxy = A70969911D146AFC00DB39D3 /* PBXContainerItemProxy */;
-		};
-		A70969B71D147B9A00DB39D3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Result-tvOS";
-			targetProxy = A70969B61D147B9A00DB39D3 /* PBXContainerItemProxy */;
-		};
-		A72A50581D00A90900894A36 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Result-iOS";
-			targetProxy = A72A50571D00A90900894A36 /* PBXContainerItemProxy */;
-		};
-		A72A508E1D00B0F300894A36 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Result-tvOS";
-			targetProxy = A72A508D1D00B0F300894A36 /* PBXContainerItemProxy */;
-		};
 		A7983B8F1C2AFB1D003A1ABE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = CA43C6621BB35FCF00C180DA /* ReactiveExtensions-tvOS */;
 			targetProxy = A7983B8E1C2AFB1D003A1ABE /* PBXContainerItemProxy */;
+		};
+		A79BE78A1E0709900077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ReactiveSwift-iOS";
+			targetProxy = A79BE7891E0709900077A9B2 /* PBXContainerItemProxy */;
+		};
+		A79BE79B1E0709940077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Result-iOS";
+			targetProxy = A79BE79A1E0709940077A9B2 /* PBXContainerItemProxy */;
+		};
+		A79BE7A31E070E670077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ReactiveSwift-iOS";
+			targetProxy = A79BE7A21E070E670077A9B2 /* PBXContainerItemProxy */;
+		};
+		A79BE7A51E070E6B0077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Result-iOS";
+			targetProxy = A79BE7A41E070E6B0077A9B2 /* PBXContainerItemProxy */;
+		};
+		A79BE7A91E07114A0077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ReactiveSwift-tvOS";
+			targetProxy = A79BE7A81E07114A0077A9B2 /* PBXContainerItemProxy */;
+		};
+		A79BE7AC1E0711530077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Result-tvOS";
+			targetProxy = A79BE7AB1E0711530077A9B2 /* PBXContainerItemProxy */;
+		};
+		A79BE7AF1E07115E0077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ReactiveSwift-tvOS";
+			targetProxy = A79BE7AE1E07115E0077A9B2 /* PBXContainerItemProxy */;
+		};
+		A79BE7B11E0711610077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Result-tvOS";
+			targetProxy = A79BE7B01E0711610077A9B2 /* PBXContainerItemProxy */;
 		};
 		A7DB1D451C9F4E3F008244DA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1342,16 +1352,6 @@
 			isa = PBXTargetDependency;
 			target = A7DB1D4C1C9F4FD7008244DA /* ReactiveExtensions-TestHelpers-tvOS */;
 			targetProxy = A7DB1D5C1C9F5008008244DA /* PBXContainerItemProxy */;
-		};
-		A7DB1D601C9F511D008244DA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ReactiveCocoa-tvOS";
-			targetProxy = A7DB1D5F1C9F511D008244DA /* PBXContainerItemProxy */;
-		};
-		A7DB1D631C9F512B008244DA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ReactiveCocoa-iOS";
-			targetProxy = A7DB1D621C9F512B008244DA /* PBXContainerItemProxy */;
 		};
 		A7FD09DB1C84902100332CCB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1364,28 +1364,26 @@
 		A7983B901C2AFB1D003A1ABE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = ReactiveExtensionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kickstarter.ReactiveExtensionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
 		A7983B941C2AFB1D003A1ABE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = ReactiveExtensionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kickstarter.ReactiveExtensionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -1393,7 +1391,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1415,7 +1413,6 @@
 				PRODUCT_NAME = ReactiveExtensions_TestHelpers;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1424,7 +1421,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1446,7 +1443,6 @@
 				PRODUCT_NAME = ReactiveExtensions_TestHelpers;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1455,6 +1451,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1477,7 +1474,6 @@
 				PRODUCT_NAME = ReactiveExtensions_TestHelpers;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1486,6 +1482,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1508,7 +1505,6 @@
 				PRODUCT_NAME = ReactiveExtensions_TestHelpers;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1518,6 +1514,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1528,7 +1525,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.ReactiveExtensions;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1538,6 +1534,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1548,7 +1545,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.ReactiveExtensions;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1556,28 +1552,26 @@
 		A7FD08DC1C81EEA100332CCB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = ReactiveExtensionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kickstarter.ReactiveExtensionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
 		A7FD08E01C81EEA100332CCB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = ReactiveExtensionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kickstarter.ReactiveExtensionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -1595,8 +1589,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -1626,6 +1622,7 @@
 				PRODUCT_NAME = ReactiveExtensions;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1647,8 +1644,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -1671,6 +1670,7 @@
 				PRODUCT_NAME = ReactiveExtensions;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -1683,6 +1683,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1693,7 +1694,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.ReactiveExtensions;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -1701,6 +1701,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1711,7 +1712,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.ReactiveExtensions;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/ReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ReactiveExtensions.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		8096F2A31CC92AAF00231D91 /* UILabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096F2A11CC92AAF00231D91 /* UILabelTests.swift */; };
 		8096F2A51CC92AB600231D91 /* UIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096F2A41CC92AB600231D91 /* UIViewTests.swift */; };
 		8096F2A61CC92AB600231D91 /* UIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096F2A41CC92AB600231D91 /* UIViewTests.swift */; };
+		A712EBA01E0C469D00614340 /* DispatchTimeInterval-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A712EB9F1E0C469D00614340 /* DispatchTimeInterval-Extensions.swift */; };
+		A712EBA11E0C469D00614340 /* DispatchTimeInterval-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A712EB9F1E0C469D00614340 /* DispatchTimeInterval-Extensions.swift */; };
+		A712EBA31E0C579700614340 /* KsrDelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A712EBA21E0C579700614340 /* KsrDelay.swift */; };
+		A712EBA41E0C579700614340 /* KsrDelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A712EBA21E0C579700614340 /* KsrDelay.swift */; };
 		A713EC791C2B55EB00B6234E /* SlidingWindowTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A713EC781C2B55EB00B6234E /* SlidingWindowTest.swift */; };
 		A713EC7D1C2B82FF00B6234E /* MapConstTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A713EC7C1C2B82FF00B6234E /* MapConstTests.swift */; };
 		A713EC7F1C2B83FF00B6234E /* DebounceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A713EC7E1C2B83FF00B6234E /* DebounceTests.swift */; };
@@ -116,7 +120,7 @@
 		A7C5104E1C27346B00C59136 /* TakeWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C5104D1C27346B00C59136 /* TakeWhen.swift */; };
 		A7C510501C2734D100C59136 /* CombinePrevious.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C5104F1C2734D100C59136 /* CombinePrevious.swift */; };
 		A7C510521C2734F100C59136 /* SlidingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510511C2734F100C59136 /* SlidingWindow.swift */; };
-		A7C510541C27351F00C59136 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510531C27351F00C59136 /* Debounce.swift */; };
+		A7C510541C27351F00C59136 /* KsrDebounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510531C27351F00C59136 /* KsrDebounce.swift */; };
 		A7C510561C27358300C59136 /* MapConst.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510551C27358300C59136 /* MapConst.swift */; };
 		A7C5105A1C2735F500C59136 /* ObserveForUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510591C2735F500C59136 /* ObserveForUI.swift */; };
 		A7C5105C1C27362000C59136 /* WrapInOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C5105B1C27362000C59136 /* WrapInOptional.swift */; };
@@ -143,7 +147,7 @@
 		A7FD088D1C81EDBD00332CCB /* LazyMutableProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7983B591C2AF7E8003A1ABE /* LazyMutableProperty.swift */; };
 		A7FD088E1C81EDBD00332CCB /* ConcatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510671C2737C500C59136 /* ConcatMap.swift */; };
 		A7FD088F1C81EDBD00332CCB /* TakeWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C5104D1C27346B00C59136 /* TakeWhen.swift */; };
-		A7FD08911C81EDBD00332CCB /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510531C27351F00C59136 /* Debounce.swift */; };
+		A7FD08911C81EDBD00332CCB /* KsrDebounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510531C27351F00C59136 /* KsrDebounce.swift */; };
 		A7FD08921C81EDBD00332CCB /* DemoteErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C5105F1C2736D400C59136 /* DemoteErrors.swift */; };
 		A7FD08931C81EDBD00332CCB /* IgnoreValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510491C2733F600C59136 /* IgnoreValues.swift */; };
 		A7FD08951C81EDBD00332CCB /* Uncollect.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C510471C2721CA00C59136 /* Uncollect.swift */; };
@@ -378,6 +382,8 @@
 		8096F29E1CC92AA700231D91 /* UIControlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControlTests.swift; sourceTree = "<group>"; };
 		8096F2A11CC92AAF00231D91 /* UILabelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabelTests.swift; sourceTree = "<group>"; };
 		8096F2A41CC92AB600231D91 /* UIViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewTests.swift; sourceTree = "<group>"; };
+		A712EB9F1E0C469D00614340 /* DispatchTimeInterval-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval-Extensions.swift"; sourceTree = "<group>"; };
+		A712EBA21E0C579700614340 /* KsrDelay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KsrDelay.swift; sourceTree = "<group>"; };
 		A713EC781C2B55EB00B6234E /* SlidingWindowTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SlidingWindowTest.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A713EC7C1C2B82FF00B6234E /* MapConstTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MapConstTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A713EC7E1C2B83FF00B6234E /* DebounceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = DebounceTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -437,7 +443,7 @@
 		A7C5104D1C27346B00C59136 /* TakeWhen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TakeWhen.swift; sourceTree = "<group>"; };
 		A7C5104F1C2734D100C59136 /* CombinePrevious.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinePrevious.swift; sourceTree = "<group>"; };
 		A7C510511C2734F100C59136 /* SlidingWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlidingWindow.swift; sourceTree = "<group>"; };
-		A7C510531C27351F00C59136 /* Debounce.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Debounce.swift; sourceTree = "<group>"; };
+		A7C510531C27351F00C59136 /* KsrDebounce.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KsrDebounce.swift; sourceTree = "<group>"; };
 		A7C510551C27358300C59136 /* MapConst.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapConst.swift; sourceTree = "<group>"; };
 		A7C510591C2735F500C59136 /* ObserveForUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObserveForUI.swift; sourceTree = "<group>"; };
 		A7C5105B1C27362000C59136 /* WrapInOptional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrapInOptional.swift; sourceTree = "<group>"; };
@@ -536,6 +542,14 @@
 				59DB70551D00DC9B00BCE6A9 /* UISwitchTests.swift */,
 			);
 			path = UIKit;
+			sourceTree = "<group>";
+		};
+		A712EB931E0C468A00614340 /* helpers */ = {
+			isa = PBXGroup;
+			children = (
+				A712EB9F1E0C469D00614340 /* DispatchTimeInterval-Extensions.swift */,
+			);
+			path = helpers;
 			sourceTree = "<group>";
 		};
 		A77966E81C2B018F0002166F /* ReactiveExtensionsTests */ = {
@@ -641,13 +655,14 @@
 				A7C5104F1C2734D100C59136 /* CombinePrevious.swift */,
 				A7180BD91CCFB0BE001711CA /* Concat.swift */,
 				A7C510671C2737C500C59136 /* ConcatMap.swift */,
-				A7C510531C27351F00C59136 /* Debounce.swift */,
 				A7C5105F1C2736D400C59136 /* DemoteErrors.swift */,
 				A72942A71DE2459000BB3455 /* Enumerated.swift */,
 				A72E75361CC1849B00983066 /* Errors.swift */,
 				A7CDB0C51C2758D80013A8F3 /* FilterWhenLatestFrom.swift */,
 				A7C510651C27378A00C59136 /* FlatMap.swift */,
 				A7C510491C2733F600C59136 /* IgnoreValues.swift */,
+				A7C510531C27351F00C59136 /* KsrDebounce.swift */,
+				A712EBA21E0C579700614340 /* KsrDelay.swift */,
 				A7C510551C27358300C59136 /* MapConst.swift */,
 				A7C510691C27380700C59136 /* MergeMap.swift */,
 				A7C510611C27371E00C59136 /* MergeWith.swift */,
@@ -720,6 +735,7 @@
 				CA43C6681BB35FCF00C180DA /* Info.plist */,
 				A7983B571C2AF232003A1ABE /* LazyAssociatedProperty.swift */,
 				A7983B591C2AF7E8003A1ABE /* LazyMutableProperty.swift */,
+				A712EB931E0C468A00614340 /* helpers */,
 				A7C510441C2720C900C59136 /* operators */,
 				A7983B5B1C2AF88A003A1ABE /* UIKit */,
 			);
@@ -1167,18 +1183,20 @@
 				A7FD088A1C81EDBD00332CCB /* SlidingWindow.swift in Sources */,
 				A7A015D71CBDA99100C4B821 /* TakeUntil.swift in Sources */,
 				A7FD088C1C81EDBD00332CCB /* FilterWhenLatestFrom.swift in Sources */,
+				A712EBA31E0C579700614340 /* KsrDelay.swift in Sources */,
 				A74FFEC31CE4ECC900C7BCB9 /* UIResponder.swift in Sources */,
 				A74FFDF51CE3ECBF00C7BCB9 /* UIBarButtonItem.swift in Sources */,
 				A7FD088D1C81EDBD00332CCB /* LazyMutableProperty.swift in Sources */,
 				A7FD088E1C81EDBD00332CCB /* ConcatMap.swift in Sources */,
 				A72E75281CC1849100983066 /* Values.swift in Sources */,
 				A7FD088F1C81EDBD00332CCB /* TakeWhen.swift in Sources */,
-				A7FD08911C81EDBD00332CCB /* Debounce.swift in Sources */,
+				A7FD08911C81EDBD00332CCB /* KsrDebounce.swift in Sources */,
 				A7FD08921C81EDBD00332CCB /* DemoteErrors.swift in Sources */,
 				A7FD08931C81EDBD00332CCB /* IgnoreValues.swift in Sources */,
 				A7141E891CFCE1BB00F1A9BE /* UIButton.swift in Sources */,
 				A72E75371CC1849B00983066 /* Errors.swift in Sources */,
 				A747A8201D455E1700AF199A /* UIStackView.swift in Sources */,
+				A712EBA01E0C469D00614340 /* DispatchTimeInterval-Extensions.swift in Sources */,
 				A7FD08951C81EDBD00332CCB /* Uncollect.swift in Sources */,
 				A743813D1D33D6D200040A95 /* NSObject.swift in Sources */,
 				A7FD08971C81EDBD00332CCB /* FlatMap.swift in Sources */,
@@ -1254,18 +1272,20 @@
 				A7C510521C2734F100C59136 /* SlidingWindow.swift in Sources */,
 				A7A015D81CBDA99100C4B821 /* TakeUntil.swift in Sources */,
 				A7CDB0C61C2758D80013A8F3 /* FilterWhenLatestFrom.swift in Sources */,
+				A712EBA41E0C579700614340 /* KsrDelay.swift in Sources */,
 				A74FFEC41CE4ECC900C7BCB9 /* UIResponder.swift in Sources */,
 				A74FFDF61CE3ECBF00C7BCB9 /* UIBarButtonItem.swift in Sources */,
 				A7983B5A1C2AF7E8003A1ABE /* LazyMutableProperty.swift in Sources */,
 				A7C510681C2737C500C59136 /* ConcatMap.swift in Sources */,
 				A72E75291CC1849100983066 /* Values.swift in Sources */,
 				A7C5104E1C27346B00C59136 /* TakeWhen.swift in Sources */,
-				A7C510541C27351F00C59136 /* Debounce.swift in Sources */,
+				A7C510541C27351F00C59136 /* KsrDebounce.swift in Sources */,
 				A7C510601C2736D400C59136 /* DemoteErrors.swift in Sources */,
 				A7C5104A1C2733F600C59136 /* IgnoreValues.swift in Sources */,
 				A7141E8A1CFCE1BB00F1A9BE /* UIButton.swift in Sources */,
 				A72E75381CC1849B00983066 /* Errors.swift in Sources */,
 				A747A8211D455E1700AF199A /* UIStackView.swift in Sources */,
+				A712EBA11E0C469D00614340 /* DispatchTimeInterval-Extensions.swift in Sources */,
 				A7C510481C2721CA00C59136 /* Uncollect.swift in Sources */,
 				A743813E1D33D6D200040A95 /* NSObject.swift in Sources */,
 				A7C510661C27378A00C59136 /* FlatMap.swift in Sources */,

--- a/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-TestHelpers-iOS.xcscheme
+++ b/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-TestHelpers-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-TestHelpers-tvOS.xcscheme
+++ b/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-TestHelpers-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-iOS.xcscheme
+++ b/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-tvOS.xcscheme
+++ b/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ReactiveExtensions/LazyAssociatedProperty.swift
+++ b/ReactiveExtensions/LazyAssociatedProperty.swift
@@ -17,8 +17,8 @@ import Foundation
  - returns: If an object is already associated to the host with the give key that object will be returned.
  Otherwise the `factory` closure is invoked and that value is returned.
  */
-internal func lazyAssociatedProperty <T: AnyObject> (host: AnyObject, key: UnsafePointer<Void>,
-                                      factory: Void -> T) -> T {
+internal func lazyAssociatedProperty <T: AnyObject> (_ host: AnyObject, key: UnsafeRawPointer,
+                                      factory: (Void) -> T) -> T {
 
   if let value = objc_getAssociatedObject(host, key) as? T {
     return value

--- a/ReactiveExtensions/LazyMutableProperty.swift
+++ b/ReactiveExtensions/LazyMutableProperty.swift
@@ -1,4 +1,4 @@
-import ReactiveCocoa
+import ReactiveSwift
 
 /**
  Associates a key/`MutableProperty` pair to a host object.
@@ -11,11 +11,11 @@ import ReactiveCocoa
 
  - returns:
  */
-public func lazyMutableProperty<T>(host: AnyObject, key: UnsafePointer<Void>, setter: T -> (),
-                                  getter: () -> T) -> MutableProperty<T> {
+public func lazyMutableProperty<T>(_ host: AnyObject, key: UnsafeRawPointer, setter: @escaping (T) -> (),
+                                  getter: @escaping () -> T) -> MutableProperty<T> {
   return lazyAssociatedProperty(host, key: key) {
     let property = MutableProperty<T>(getter())
-    property.producer.skip(1).startWithNext { value in
+    property.producer.skip(first: 1).startWithValues { value in
       setter(value)
     }
     return property

--- a/ReactiveExtensions/LazyMutableProperty.swift
+++ b/ReactiveExtensions/LazyMutableProperty.swift
@@ -11,7 +11,7 @@ import ReactiveSwift
 
  - returns:
  */
-public func lazyMutableProperty<T>(_ host: AnyObject, key: UnsafeRawPointer, setter: @escaping (T) -> (),
+public func lazyMutableProperty<T>(_ host: AnyObject, key: UnsafeRawPointer, setter: @escaping (T) -> Void,
                                   getter: @escaping () -> T) -> MutableProperty<T> {
   return lazyAssociatedProperty(host, key: key) {
     let property = MutableProperty<T>(getter())

--- a/ReactiveExtensions/UIKit/NSLayoutConstraint.swift
+++ b/ReactiveExtensions/UIKit/NSLayoutConstraint.swift
@@ -1,9 +1,9 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var constant = 0
+  fileprivate static var constant = 0
 }
 
 public extension Rac where Object: NSLayoutConstraint {

--- a/ReactiveExtensions/UIKit/NSObject.swift
+++ b/ReactiveExtensions/UIKit/NSObject.swift
@@ -1,14 +1,14 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var accessibilityElementsHidden = 0
-  private static var accessibilityHint = 1
-  private static var accessibilityLabel = 2
-  private static var accessibilityTraits = 3
-  private static var accessibilityValue = 4
-  private static var isAccessibilityElement = 5
+  fileprivate static var accessibilityElementsHidden = 0
+  fileprivate static var accessibilityHint = 1
+  fileprivate static var accessibilityLabel = 2
+  fileprivate static var accessibilityTraits = 3
+  fileprivate static var accessibilityValue = 4
+  fileprivate static var isAccessibilityElement = 5
 }
 
 public extension Rac where Object: NSObject {

--- a/ReactiveExtensions/UIKit/UIActivityIndicator.swift
+++ b/ReactiveExtensions/UIKit/UIActivityIndicator.swift
@@ -1,9 +1,9 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var animating = 0
+  fileprivate static var animating = 0
 }
 
 public extension Rac where Object: UIActivityIndicatorView {
@@ -13,7 +13,7 @@ public extension Rac where Object: UIActivityIndicatorView {
         object,
         key: &Associations.animating,
         setter: { [weak object] in $0 ? object?.startAnimating() : object?.stopAnimating() },
-        getter: { [weak object] in object?.isAnimating() ?? false })
+        getter: { [weak object] in object?.isAnimating ?? false })
 
       prop <~ newValue.observeForUI()
     }

--- a/ReactiveExtensions/UIKit/UIBarButtonItem.swift
+++ b/ReactiveExtensions/UIKit/UIBarButtonItem.swift
@@ -1,9 +1,9 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var enabled = 0
+  fileprivate static var enabled = 0
 }
 
 public extension Rac where Object: UIBarButtonItem {
@@ -12,8 +12,8 @@ public extension Rac where Object: UIBarButtonItem {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object,
         key: &Associations.enabled,
-        setter: { [weak object] in object?.enabled = $0 ?? true },
-        getter: { [weak object] in object?.enabled ?? true })
+        setter: { [weak object] in object?.isEnabled = $0 },
+        getter: { [weak object] in object?.isEnabled ?? true })
 
       prop <~ newValue.observeForUI()
     }

--- a/ReactiveExtensions/UIKit/UIButton.swift
+++ b/ReactiveExtensions/UIKit/UIButton.swift
@@ -1,10 +1,10 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var title = 0
-  private static var attributedTitle = 1
+  fileprivate static var title = 0
+  fileprivate static var attributedTitle = 1
 }
 
 public extension Rac where Object: UIButton {
@@ -13,7 +13,7 @@ public extension Rac where Object: UIButton {
       let prop: MutableProperty<String> = lazyMutableProperty(
         object,
         key: &Associations.title,
-        setter: { [weak object] in object?.setTitle($0, forState: .Normal) },
+        setter: { [weak object] in object?.setTitle($0, for: .normal) },
         getter: { [weak object] in object?.titleLabel?.text ?? "" })
 
       prop <~ newValue.observeForUI()
@@ -29,7 +29,7 @@ public extension Rac where Object: UIButton {
       let prop: MutableProperty<NSAttributedString> = lazyMutableProperty(
         object,
         key: &Associations.attributedTitle,
-        setter: { [weak object] in object?.setAttributedTitle($0, forState: .Normal) },
+        setter: { [weak object] in object?.setAttributedTitle($0, for: .normal) },
         getter: { [weak object] in object?.titleLabel?.attributedText ?? NSAttributedString(string: "") })
 
       prop <~ newValue.observeForUI()

--- a/ReactiveExtensions/UIKit/UIControl.swift
+++ b/ReactiveExtensions/UIKit/UIControl.swift
@@ -1,18 +1,18 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var enabled = 0
-  private static var selected = 1
+  fileprivate static var enabled = 0
+  fileprivate static var selected = 1
 }
 
 public extension Rac where Object: UIControl {
   public var enabled: Signal<Bool, NoError> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(object, key: &Associations.enabled,
-        setter: { [weak object] in object?.enabled = $0 },
-        getter: { [weak object] in object?.enabled ?? true })
+        setter: { [weak object] in object?.isEnabled = $0 },
+        getter: { [weak object] in object?.isEnabled ?? true })
 
       prop <~ newValue.observeForUI()
     }
@@ -26,8 +26,8 @@ public extension Rac where Object: UIControl {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object, key: &Associations.selected,
-        setter: { [weak object] in object?.selected = $0 },
-        getter: { [weak object] in object?.selected ?? false })
+        setter: { [weak object] in object?.isSelected = $0 },
+        getter: { [weak object] in object?.isSelected ?? false })
 
       prop <~ newValue.observeForUI()
     }

--- a/ReactiveExtensions/UIKit/UILabel.swift
+++ b/ReactiveExtensions/UIKit/UILabel.swift
@@ -1,12 +1,12 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var attributedText = 0
-  private static var font = 1
-  private static var text = 2
-  private static var textColor = 3
+  fileprivate static var attributedText = 0
+  fileprivate static var font = 1
+  fileprivate static var text = 2
+  fileprivate static var textColor = 3
 }
 
 public extension Rac where Object: UILabel {
@@ -48,7 +48,7 @@ public extension Rac where Object: UILabel {
         object,
         key: &Associations.font,
         setter: { [weak object] in object?.font = $0 },
-        getter: { [weak object] in object?.font ?? .systemFontOfSize(12.0) })
+        getter: { [weak object] in object?.font ?? .systemFont(ofSize: 12.0) })
 
       prop <~ newValue.observeForUI()
     }
@@ -64,7 +64,7 @@ public extension Rac where Object: UILabel {
         object,
         key: &Associations.textColor,
         setter: { [weak object] in object?.textColor = $0 },
-        getter: { [weak object] in object?.textColor ?? .blackColor() })
+        getter: { [weak object] in object?.textColor ?? .black })
 
       prop <~ newValue.observeForUI()
     }

--- a/ReactiveExtensions/UIKit/UINavigationItem.swift
+++ b/ReactiveExtensions/UIKit/UINavigationItem.swift
@@ -1,9 +1,9 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var title = 0
+  fileprivate static var title = 0
 }
 
 public extension Rac where Object: UINavigationItem {

--- a/ReactiveExtensions/UIKit/UIRefreshControl.swift
+++ b/ReactiveExtensions/UIKit/UIRefreshControl.swift
@@ -1,10 +1,10 @@
 #if os(iOS)
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var isRefreshing = 0
+  fileprivate static var isRefreshing = 0
 }
 
 public extension Rac where Object: UIRefreshControl {
@@ -14,7 +14,7 @@ public extension Rac where Object: UIRefreshControl {
         object,
         key: &Associations.isRefreshing,
         setter: { [weak object] in $0 ? object?.beginRefreshing() : object?.endRefreshing() },
-        getter: { [weak object] in object?.refreshing ?? false })
+        getter: { [weak object] in object?.isRefreshing ?? false })
 
       prop <~ newValue.observeForUI()
     }

--- a/ReactiveExtensions/UIKit/UIResponder.swift
+++ b/ReactiveExtensions/UIKit/UIResponder.swift
@@ -1,10 +1,10 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var becomeFirstResponder = 0
-  private static var firstResponder = 1
+  fileprivate static var becomeFirstResponder = 0
+  fileprivate static var firstResponder = 1
 }
 
 public extension Rac where Object: UIResponder {
@@ -31,8 +31,10 @@ public extension Rac where Object: UIResponder {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object,
         key: &Associations.firstResponder,
-        setter: { [weak object] in $0 ? object?.becomeFirstResponder() : object?.resignFirstResponder() },
-        getter: { [weak object] in object?.isFirstResponder() ?? false })
+        setter: { [weak object] in
+          _ = $0 ? object?.becomeFirstResponder() : object?.resignFirstResponder()
+        },
+        getter: { [weak object] in object?.isFirstResponder ?? false })
 
       prop <~ newValue.observeForUI()
     }

--- a/ReactiveExtensions/UIKit/UIStackView.swift
+++ b/ReactiveExtensions/UIKit/UIStackView.swift
@@ -1,10 +1,10 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var alignment = 0
-  private static var axis = 1
+  fileprivate static var alignment = 0
+  fileprivate static var axis = 1
 }
 
 public extension Rac where Object: UIStackView {
@@ -13,7 +13,7 @@ public extension Rac where Object: UIStackView {
       let prop: MutableProperty<UILayoutConstraintAxis> = lazyMutableProperty(
         object, key: &Associations.axis,
         setter: { [weak object] in object?.axis = $0 },
-        getter: { [weak object] in object?.axis ?? .Horizontal })
+        getter: { [weak object] in object?.axis ?? .horizontal })
 
       prop <~ newValue.observeForUI()
     }
@@ -27,7 +27,7 @@ public extension Rac where Object: UIStackView {
       let prop: MutableProperty<UIStackViewAlignment> = lazyMutableProperty(
         object, key: &Associations.alignment,
         setter: { [weak object] in object?.alignment = $0 },
-        getter: { [weak object] in object?.alignment ?? .Fill })
+        getter: { [weak object] in object?.alignment ?? .fill })
 
       prop <~ newValue.observeForUI()
     }

--- a/ReactiveExtensions/UIKit/UISwitch.swift
+++ b/ReactiveExtensions/UIKit/UISwitch.swift
@@ -1,10 +1,10 @@
 #if os(iOS)
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var on = 0
+  fileprivate static var on = 0
 }
 
 public extension Rac where Object: UISwitch {
@@ -12,8 +12,8 @@ public extension Rac where Object: UISwitch {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object, key: &Associations.on,
-        setter: { [weak object] in object?.on = $0 },
-        getter: { [weak object] in object?.on ?? false })
+        setter: { [weak object] in object?.isOn = $0 },
+        getter: { [weak object] in object?.isOn ?? false })
 
       prop <~ newValue.observeForUI()
     }

--- a/ReactiveExtensions/UIKit/UITextField.swift
+++ b/ReactiveExtensions/UIKit/UITextField.swift
@@ -1,9 +1,9 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var text = 0
+  fileprivate static var text = 0
 }
 
 public extension Rac where Object: UITextField {

--- a/ReactiveExtensions/UIKit/UITextView.swift
+++ b/ReactiveExtensions/UIKit/UITextView.swift
@@ -1,9 +1,9 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var text = 0
+  fileprivate static var text = 0
 }
 
 public extension Rac where Object: UITextView {

--- a/ReactiveExtensions/UIKit/UIView.swift
+++ b/ReactiveExtensions/UIKit/UIView.swift
@@ -1,13 +1,13 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import UIKit
 
 private enum Associations {
-  private static var alpha = 0
-  private static var backgroundColor = 0
-  private static var endEditing = 0
-  private static var hidden = 0
-  private static var tintColor = 0
+  fileprivate static var alpha = 0
+  fileprivate static var backgroundColor = 0
+  fileprivate static var endEditing = 0
+  fileprivate static var hidden = 0
+  fileprivate static var tintColor = 0
 }
 
 public extension Rac where Object: UIView {
@@ -30,7 +30,7 @@ public extension Rac where Object: UIView {
     nonmutating set {
       let prop: MutableProperty<UIColor> = lazyMutableProperty(object, key: &Associations.backgroundColor,
         setter: { [weak object] in object?.backgroundColor = $0 },
-        getter: { [weak object] in object?.backgroundColor ?? .clearColor() })
+        getter: { [weak object] in object?.backgroundColor ?? .clear })
 
       prop <~ newValue.observeForUI()
     }
@@ -57,8 +57,8 @@ public extension Rac where Object: UIView {
   public var hidden: Signal<Bool, NoError> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(object, key: &Associations.hidden,
-        setter: { [weak object] in object?.hidden = $0 },
-        getter: { [weak object] in object?.hidden ?? false })
+        setter: { [weak object] in object?.isHidden = $0 },
+        getter: { [weak object] in object?.isHidden ?? false })
 
       prop <~ newValue.observeForUI()
     }
@@ -74,7 +74,7 @@ public extension Rac where Object: UIView {
         object,
         key: &Associations.tintColor,
         setter: { [weak object] in object?.tintColor = $0 },
-        getter: { [weak object] in object?.tintColor ?? .clearColor() })
+        getter: { [weak object] in object?.tintColor ?? .clear })
 
       prop <~ newValue.observeForUI()
     }

--- a/ReactiveExtensions/helpers/DispatchTimeInterval-Extensions.swift
+++ b/ReactiveExtensions/helpers/DispatchTimeInterval-Extensions.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension DispatchTimeInterval {
+  internal var timeInterval: TimeInterval {
+    switch self {
+    case let .seconds(interval):
+      return TimeInterval(interval)
+    case let .milliseconds(interval):
+      return TimeInterval(interval) / 1_000
+    case let .microseconds(interval):
+      return TimeInterval(interval) / 1_000_000
+    case let .nanoseconds(interval):
+      return TimeInterval(interval) / 1_000_000_000
+    }
+  }
+}

--- a/ReactiveExtensions/operators/AllValues.swift
+++ b/ReactiveExtensions/operators/AllValues.swift
@@ -11,7 +11,6 @@ public extension SignalProducerProtocol {
 
    - returns: All values emitted by the signal producer.
    */
-  
   public func allValues() -> [Value] {
     return self.producer.collect().last()?.value ?? []
   }

--- a/ReactiveExtensions/operators/AllValues.swift
+++ b/ReactiveExtensions/operators/AllValues.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
   /**
    Starts the producer, collects all the values emitted until it completes, and returns an array of all
@@ -11,7 +11,7 @@ public extension SignalProducerType {
 
    - returns: All values emitted by the signal producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
+  
   public func allValues() -> [Value] {
     return self.producer.collect().last()?.value ?? []
   }

--- a/ReactiveExtensions/operators/CombinePrevious.swift
+++ b/ReactiveExtensions/operators/CombinePrevious.swift
@@ -2,7 +2,6 @@ import ReactiveSwift
 
 public extension SignalProtocol {
 
-  
   /**
    Returns a signal of pairs: the previously emitted value and the currently emitted value. The first
    emission is skipped, so non-optional `Value`s are returned.
@@ -21,7 +20,6 @@ public extension SignalProtocol {
 
 public extension SignalProducerProtocol {
 
-  
   /**
    Returns a producer of pairs: the previously emitted value and the currently emitted value. The first
    emission is skipped, so non-optional `Value`s are returned.

--- a/ReactiveExtensions/operators/CombinePrevious.swift
+++ b/ReactiveExtensions/operators/CombinePrevious.swift
@@ -1,8 +1,8 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   /**
    Returns a signal of pairs: the previously emitted value and the currently emitted value. The first
    emission is skipped, so non-optional `Value`s are returned.
@@ -14,14 +14,14 @@ public extension SignalType {
     return self.signal
       .wrapInOptional()
       .combinePrevious(nil)
-      .skip(1)
+      .skip(first: 1)
       .map { (old, new) in (old!, new!) }
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
+  
   /**
    Returns a producer of pairs: the previously emitted value and the currently emitted value. The first
    emission is skipped, so non-optional `Value`s are returned.

--- a/ReactiveExtensions/operators/Concat.swift
+++ b/ReactiveExtensions/operators/Concat.swift
@@ -24,7 +24,6 @@ extension SignalProtocol {
     return result
   }
 
-  
   public static func concat<S: SignalProtocol>
     (_ signals: S...) -> Signal<Value, Error> where S.Value == Value, S.Error == Error {
 
@@ -40,7 +39,7 @@ extension SignalProducerProtocol {
 
    - returns: A concatenated producer.
    */
-  
+
   public static func concat
     <Seq: Sequence, S: SignalProducerProtocol>
     (_ producers: Seq) -> SignalProducer<Value, Error> where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S {
@@ -48,7 +47,6 @@ extension SignalProducerProtocol {
     return SignalProducer(producers).flatten(.concat)
   }
 
-  
   public static func concat<S: SignalProducerProtocol>
     (_ producers: S...) -> SignalProducer<Value, Error> where S.Value == Value, S.Error == Error {
 

--- a/ReactiveExtensions/operators/Concat.swift
+++ b/ReactiveExtensions/operators/Concat.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable line_length
-import ReactiveCocoa
+import ReactiveSwift
 
-extension SignalType {
+extension SignalProtocol {
 
   /**
    Concats a sequence of signals into a single signal.
@@ -11,28 +11,28 @@ extension SignalType {
    - returns: A concatenated signal.
    */
   public static func concat
-    <Seq: SequenceType, S: SignalType where S.Value == Value, S.Error == Error, Seq.Generator.Element == S>
-    (signals: Seq) -> Signal<Value, Error> {
+    <Seq: Sequence, S: SignalProtocol>
+    (_ signals: Seq) -> Signal<Value, Error> where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S {
 
-    let producer = SignalProducer<S, Error>(values: signals)
+    let producer = SignalProducer<S, Error>(signals)
     var result: Signal<Value, Error>!
 
     producer.startWithSignal { signal, _ in
-      result = signal.flatten(.Concat)
+      result = signal.flatten(.concat)
     }
 
     return result
   }
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public static func concat<S: SignalType where S.Value == Value, S.Error == Error>
-    (signals: S...) -> Signal<Value, Error> {
+  
+  public static func concat<S: SignalProtocol>
+    (_ signals: S...) -> Signal<Value, Error> where S.Value == Value, S.Error == Error {
 
     return Signal.concat(signals)
   }
 }
 
-extension SignalProducerType {
+extension SignalProducerProtocol {
   /**
    Concats a sequence of producers into a single producer.
 
@@ -40,17 +40,17 @@ extension SignalProducerType {
 
    - returns: A concatenated producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
+  
   public static func concat
-    <Seq: SequenceType, S: SignalProducerType where S.Value == Value, S.Error == Error, Seq.Generator.Element == S>
-    (producers: Seq) -> SignalProducer<Value, Error> {
+    <Seq: Sequence, S: SignalProducerProtocol>
+    (_ producers: Seq) -> SignalProducer<Value, Error> where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S {
 
-    return SignalProducer(values: producers).flatten(.Concat)
+    return SignalProducer(producers).flatten(.concat)
   }
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public static func concat<S: SignalProducerType where S.Value == Value, S.Error == Error>
-    (producers: S...) -> SignalProducer<Value, Error> {
+  
+  public static func concat<S: SignalProducerProtocol>
+    (_ producers: S...) -> SignalProducer<Value, Error> where S.Value == Value, S.Error == Error {
 
     return SignalProducer.concat(producers)
   }

--- a/ReactiveExtensions/operators/ConcatMap.swift
+++ b/ReactiveExtensions/operators/ConcatMap.swift
@@ -2,12 +2,10 @@ import ReactiveSwift
 
 public extension SignalProtocol {
 
-  
   public func concatMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
     return self.signal.flatMap(.concat, transform: f)
   }
 
-  
   public func concatMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
     return self.signal.flatMap(.concat, transform: f)
   }
@@ -15,12 +13,10 @@ public extension SignalProtocol {
 
 public extension SignalProducerProtocol {
 
-  
   public func concatMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
     return self.producer.flatMap(.concat, transform: f)
   }
 
-  
   public func concatMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
     return self.producer.flatMap(.concat, transform: f)
   }

--- a/ReactiveExtensions/operators/ConcatMap.swift
+++ b/ReactiveExtensions/operators/ConcatMap.swift
@@ -1,27 +1,27 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func concatMap <U> (f: Value -> SignalProducer<U, Error>) -> Signal<U, Error> {
-    return self.signal.flatMap(.Concat, transform: f)
+  
+  public func concatMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
+    return self.signal.flatMap(.concat, transform: f)
   }
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func concatMap <U> (f: Value -> Signal<U, Error>) -> Signal<U, Error> {
-    return self.signal.flatMap(.Concat, transform: f)
+  
+  public func concatMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
+    return self.signal.flatMap(.concat, transform: f)
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func concatMap <U> (f: Value -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
-    return self.producer.flatMap(.Concat, transform: f)
+  
+  public func concatMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
+    return self.producer.flatMap(.concat, transform: f)
   }
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func concatMap <U> (f: Value -> Signal<U, Error>) -> SignalProducer<U, Error> {
-    return self.producer.flatMap(.Concat, transform: f)
+  
+  public func concatMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
+    return self.producer.flatMap(.concat, transform: f)
   }
 }

--- a/ReactiveExtensions/operators/Debounce.swift
+++ b/ReactiveExtensions/operators/Debounce.swift
@@ -34,7 +34,8 @@ public extension SignalProducerProtocol {
    */
   public func ksr_debounce(
     _ interval: @autoclosure @escaping () -> TimeInterval,
-    onScheduler scheduler: @autoclosure @escaping () -> DateSchedulerProtocol) -> SignalProducer<Value, Error> {
+    onScheduler scheduler: @autoclosure @escaping () -> DateSchedulerProtocol)
+    -> SignalProducer<Value, Error> {
 
       return lift { $0.ksr_debounce(interval(), onScheduler: scheduler()) }
   }

--- a/ReactiveExtensions/operators/Debounce.swift
+++ b/ReactiveExtensions/operators/Debounce.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Debounces a signal by a time interval. The resulting signal emits a value only when `interval` seconds
@@ -11,18 +11,18 @@ public extension SignalType {
 
    - returns: A new signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   public func ksr_debounce(
-    @autoclosure(escaping) interval: () -> NSTimeInterval,
-    @autoclosure(escaping) onScheduler scheduler: () -> DateSchedulerType) -> Signal<Value, Error> {
+    _ interval: @autoclosure @escaping () -> TimeInterval,
+    onScheduler scheduler: @autoclosure @escaping () -> DateSchedulerProtocol) -> Signal<Value, Error> {
 
-      return self.flatMap(.Latest) { next in
-        SignalProducer(value: next).delay(interval(), onScheduler: scheduler())
+      return self.flatMap(.latest) { next in
+        SignalProducer(value: next).delay(interval(), on: scheduler())
       }
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
   /**
    Debounces a producer by a time interval. The resulting producer emits a value only when `interval` seconds
@@ -33,10 +33,10 @@ public extension SignalProducerType {
 
    - returns: A new producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
+  
   public func ksr_debounce(
-    @autoclosure(escaping) interval: () -> NSTimeInterval,
-    @autoclosure(escaping) onScheduler scheduler: () -> DateSchedulerType) -> SignalProducer<Value, Error> {
+    _ interval: @autoclosure @escaping () -> TimeInterval,
+    onScheduler scheduler: @autoclosure @escaping () -> DateSchedulerProtocol) -> SignalProducer<Value, Error> {
 
       return lift { $0.ksr_debounce(interval(), onScheduler: scheduler()) }
   }

--- a/ReactiveExtensions/operators/Debounce.swift
+++ b/ReactiveExtensions/operators/Debounce.swift
@@ -13,7 +13,7 @@ public extension SignalProtocol {
    */
   public func ksr_debounce(
     _ interval: @autoclosure @escaping () -> TimeInterval,
-    onScheduler scheduler: @autoclosure @escaping () -> DateSchedulerProtocol) -> Signal<Value, Error> {
+    on scheduler: @autoclosure @escaping () -> DateSchedulerProtocol) -> Signal<Value, Error> {
 
       return self.flatMap(.latest) { next in
         SignalProducer(value: next).delay(interval(), on: scheduler())
@@ -34,9 +34,9 @@ public extension SignalProducerProtocol {
    */
   public func ksr_debounce(
     _ interval: @autoclosure @escaping () -> TimeInterval,
-    onScheduler scheduler: @autoclosure @escaping () -> DateSchedulerProtocol)
+    on scheduler: @autoclosure @escaping () -> DateSchedulerProtocol)
     -> SignalProducer<Value, Error> {
 
-      return lift { $0.ksr_debounce(interval(), onScheduler: scheduler()) }
+      return lift { $0.ksr_debounce(interval(), on: scheduler()) }
   }
 }

--- a/ReactiveExtensions/operators/Debounce.swift
+++ b/ReactiveExtensions/operators/Debounce.swift
@@ -11,7 +11,6 @@ public extension SignalProtocol {
 
    - returns: A new signal.
    */
-  
   public func ksr_debounce(
     _ interval: @autoclosure @escaping () -> TimeInterval,
     onScheduler scheduler: @autoclosure @escaping () -> DateSchedulerProtocol) -> Signal<Value, Error> {
@@ -33,7 +32,6 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer.
    */
-  
   public func ksr_debounce(
     _ interval: @autoclosure @escaping () -> TimeInterval,
     onScheduler scheduler: @autoclosure @escaping () -> DateSchedulerProtocol) -> SignalProducer<Value, Error> {

--- a/ReactiveExtensions/operators/DemoteErrors.swift
+++ b/ReactiveExtensions/operators/DemoteErrors.swift
@@ -11,7 +11,6 @@ public extension SignalProtocol {
 
    - returns: A new signal that will never error.
    */
-  
   public func demoteErrors(replaceErrorWith value: Value? = nil) -> Signal<Value, NoError> {
 
     return self.signal
@@ -33,7 +32,6 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer that will never error.
    */
-  
   public func demoteErrors(replaceErrorWith value: Value? = nil) -> SignalProducer<Value, NoError> {
     return self.lift { $0.demoteErrors(replaceErrorWith: value) }
   }

--- a/ReactiveExtensions/operators/DemoteErrors.swift
+++ b/ReactiveExtensions/operators/DemoteErrors.swift
@@ -14,7 +14,7 @@ public extension SignalProtocol {
   public func demoteErrors(replaceErrorWith value: Value? = nil) -> Signal<Value, NoError> {
 
     return self.signal
-      .flatMapError { error in
+      .flatMapError { _ in
         if let value = value {
           return SignalProducer(value: value)
         }

--- a/ReactiveExtensions/operators/DemoteErrors.swift
+++ b/ReactiveExtensions/operators/DemoteErrors.swift
@@ -1,7 +1,7 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Demotes the `Error` of this signal to `NoError`, thus preventing it from ever erroring. Essentially the
@@ -11,7 +11,7 @@ public extension SignalType {
 
    - returns: A new signal that will never error.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   public func demoteErrors(replaceErrorWith value: Value? = nil) -> Signal<Value, NoError> {
 
     return self.signal
@@ -24,7 +24,7 @@ public extension SignalType {
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
   /**
    Demotes the `Error` of the producer to `NoError`, thus preventing it from ever erroring. Essentially the
    inverse of `promoteErrors`.
@@ -33,7 +33,7 @@ public extension SignalProducerType {
 
    - returns: A new producer that will never error.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
+  
   public func demoteErrors(replaceErrorWith value: Value? = nil) -> SignalProducer<Value, NoError> {
     return self.lift { $0.demoteErrors(replaceErrorWith: value) }
   }

--- a/ReactiveExtensions/operators/Enumerated.swift
+++ b/ReactiveExtensions/operators/Enumerated.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-extension SignalType {
+extension SignalProtocol {
   /**
    Transforms a signal into one that also emits the index count of the emission, i.e. a signal with emissions
 

--- a/ReactiveExtensions/operators/Errors.swift
+++ b/ReactiveExtensions/operators/Errors.swift
@@ -1,16 +1,16 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 
-extension SignalType where Value: EventType, Error == NoError {
+extension SignalProtocol where Value: EventProtocol, Error == NoError {
   /**
    - returns: A signal of errors of `Error` events from a materialized signal.
    */
   public func errors() -> Signal<Value.Error, NoError> {
-    return self.signal.map { $0.event.error }.ignoreNil()
+    return self.signal.map { $0.event.error }.skipNil()
   }
 }
 
-extension SignalProducerType where Value: EventType, Error == NoError {
+extension SignalProducerProtocol where Value: EventProtocol, Error == NoError {
   /**
    - returns: A producer of errors of `Error` events from a materialized signal.
    */

--- a/ReactiveExtensions/operators/FilterWhenLatestFrom.swift
+++ b/ReactiveExtensions/operators/FilterWhenLatestFrom.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Filters a signal by using a predicate on the latest emitted value from another signal.
@@ -11,7 +11,7 @@ public extension SignalType {
 
    - Returns: A new signal of type `(Value, Error)`.
    */
-  public func filterWhenLatestFrom <U> (other: Signal<U, Error>, satisfies: U -> Bool)
+  public func filterWhenLatestFrom <U> (_ other: Signal<U, Error>, satisfies: @escaping (U) -> Bool)
     -> Signal<Value, Error> {
 
     return self.signal.withLatestFrom(other)

--- a/ReactiveExtensions/operators/FlatMap.swift
+++ b/ReactiveExtensions/operators/FlatMap.swift
@@ -2,12 +2,10 @@ import ReactiveSwift
 
 public extension SignalProtocol {
 
-  
   public func flatMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
     return self.signal.flatMap(.concat, transform: f)
   }
 
-  
   public func flatMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
     return self.signal.flatMap(.concat, transform: f)
   }
@@ -15,12 +13,10 @@ public extension SignalProtocol {
 
 public extension SignalProducerProtocol {
 
-  
   public func flatMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
     return self.producer.flatMap(.concat, transform: f)
   }
 
-  
   public func flatMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
     return self.producer.flatMap(.concat, transform: f)
   }

--- a/ReactiveExtensions/operators/FlatMap.swift
+++ b/ReactiveExtensions/operators/FlatMap.swift
@@ -1,27 +1,27 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func flatMap <U> (f: Value -> SignalProducer<U, Error>) -> Signal<U, Error> {
-    return self.signal.flatMap(.Concat, transform: f)
+  
+  public func flatMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
+    return self.signal.flatMap(.concat, transform: f)
   }
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func flatMap <U> (f: Value -> Signal<U, Error>) -> Signal<U, Error> {
-    return self.signal.flatMap(.Concat, transform: f)
+  
+  public func flatMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
+    return self.signal.flatMap(.concat, transform: f)
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func flatMap <U> (f: Value -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
-    return self.producer.flatMap(.Concat, transform: f)
+  
+  public func flatMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
+    return self.producer.flatMap(.concat, transform: f)
   }
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func flatMap <U> (f: Value -> Signal<U, Error>) -> SignalProducer<U, Error> {
-    return self.producer.flatMap(.Concat, transform: f)
+  
+  public func flatMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
+    return self.producer.flatMap(.concat, transform: f)
   }
 }

--- a/ReactiveExtensions/operators/IgnoreValues.swift
+++ b/ReactiveExtensions/operators/IgnoreValues.swift
@@ -1,26 +1,26 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Creates a new signal that emits a void value for every emission of `self`.
 
    - returns: A new signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   public func ignoreValues() -> Signal<Void, Error> {
     return signal.map { _ in () }
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
   /**
    Creates a new producer that emits a void value for every emission of `self`.
 
    - returns: A new producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
+  
   public func ignoreValues() -> SignalProducer<Void, Error> {
     return lift { $0.ignoreValues() }
   }

--- a/ReactiveExtensions/operators/IgnoreValues.swift
+++ b/ReactiveExtensions/operators/IgnoreValues.swift
@@ -7,7 +7,6 @@ public extension SignalProtocol {
 
    - returns: A new signal.
    */
-  
   public func ignoreValues() -> Signal<Void, Error> {
     return signal.map { _ in () }
   }
@@ -20,7 +19,6 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer.
    */
-  
   public func ignoreValues() -> SignalProducer<Void, Error> {
     return lift { $0.ignoreValues() }
   }

--- a/ReactiveExtensions/operators/KsrDebounce.swift
+++ b/ReactiveExtensions/operators/KsrDebounce.swift
@@ -12,11 +12,11 @@ public extension SignalProtocol {
    - returns: A new signal.
    */
   public func ksr_debounce(
-    _ interval: @autoclosure @escaping () -> TimeInterval,
+    _ interval: @autoclosure @escaping () -> DispatchTimeInterval,
     on scheduler: @autoclosure @escaping () -> DateSchedulerProtocol) -> Signal<Value, Error> {
 
       return self.flatMap(.latest) { next in
-        SignalProducer(value: next).delay(interval(), on: scheduler())
+        SignalProducer(value: next).delay(interval().timeInterval, on: scheduler())
       }
   }
 }
@@ -33,7 +33,7 @@ public extension SignalProducerProtocol {
    - returns: A new producer.
    */
   public func ksr_debounce(
-    _ interval: @autoclosure @escaping () -> TimeInterval,
+    _ interval: @autoclosure @escaping () -> DispatchTimeInterval,
     on scheduler: @autoclosure @escaping () -> DateSchedulerProtocol)
     -> SignalProducer<Value, Error> {
 

--- a/ReactiveExtensions/operators/KsrDelay.swift
+++ b/ReactiveExtensions/operators/KsrDelay.swift
@@ -1,0 +1,39 @@
+import ReactiveSwift
+
+public extension SignalProtocol {
+
+  /**
+   Debounces a signal by a time interval. The resulting signal emits a value only when `interval` seconds
+   have passed since the last emission of `self`.
+
+   - parameter interval:  The time to wait since last emission.
+   - parameter scheduler: A scheduler.
+
+   - returns: A new signal.
+   */
+  public func ksr_delay(_ interval: @autoclosure @escaping () -> DispatchTimeInterval,
+                        on scheduler: @autoclosure @escaping () -> DateSchedulerProtocol)
+    -> Signal<Value, Error> {
+
+      return self.delay(interval().timeInterval, on: scheduler())
+  }
+}
+
+public extension SignalProducerProtocol {
+
+  /**
+   Debounces a producer by a time interval. The resulting producer emits a value only when `interval` seconds
+   have passed since the last emission of `self`.
+
+   - parameter interval:  The time to wait since last emission.
+   - parameter scheduler: A scheduler.
+
+   - returns: A new producer.
+   */
+  public func ksr_delay(_ interval: @autoclosure @escaping () -> DispatchTimeInterval,
+                        on scheduler: @autoclosure @escaping () -> DateSchedulerProtocol)
+    -> SignalProducer<Value, Error> {
+
+      return self.delay(interval().timeInterval, on: scheduler())
+  }
+}

--- a/ReactiveExtensions/operators/MapConst.swift
+++ b/ReactiveExtensions/operators/MapConst.swift
@@ -9,7 +9,6 @@ public extension SignalProtocol {
 
    - returns: A new signal.
    */
-  
   public func mapConst <U> (_ value: U) -> Signal<U, Error> {
     return self.signal.map { _ in value }
   }
@@ -24,7 +23,6 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer.
    */
-  
   public func mapConst <U> (_ value: U) -> SignalProducer<U, Error> {
     return lift { $0.mapConst(value) }
   }

--- a/ReactiveExtensions/operators/MapConst.swift
+++ b/ReactiveExtensions/operators/MapConst.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Maps a signal to a const.
@@ -9,13 +9,13 @@ public extension SignalType {
 
    - returns: A new signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func mapConst <U> (value: U) -> Signal<U, Error> {
+  
+  public func mapConst <U> (_ value: U) -> Signal<U, Error> {
     return self.signal.map { _ in value }
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
   /**
    Maps a producer to a const.
@@ -24,8 +24,8 @@ public extension SignalProducerType {
 
    - returns: A new producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func mapConst <U> (value: U) -> SignalProducer<U, Error> {
+  
+  public func mapConst <U> (_ value: U) -> SignalProducer<U, Error> {
     return lift { $0.mapConst(value) }
   }
 }

--- a/ReactiveExtensions/operators/MergeMap.swift
+++ b/ReactiveExtensions/operators/MergeMap.swift
@@ -1,27 +1,27 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func mergeMap <U> (f: Value -> SignalProducer<U, Error>) -> Signal<U, Error> {
-    return self.signal.flatMap(.Merge, transform: f)
+  
+  public func mergeMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
+    return self.signal.flatMap(.merge, transform: f)
   }
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func mergeMap <U> (f: Value -> Signal<U, Error>) -> Signal<U, Error> {
-    return self.signal.flatMap(.Merge, transform: f)
+  
+  public func mergeMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
+    return self.signal.flatMap(.merge, transform: f)
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func mergeMap <U> (f: Value -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
-    return self.producer.flatMap(.Merge, transform: f)
+  
+  public func mergeMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
+    return self.producer.flatMap(.merge, transform: f)
   }
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func mergeMap <U> (f: Value -> Signal<U, Error>) -> SignalProducer<U, Error> {
-    return self.producer.flatMap(.Merge, transform: f)
+  
+  public func mergeMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
+    return self.producer.flatMap(.merge, transform: f)
   }
 }

--- a/ReactiveExtensions/operators/MergeMap.swift
+++ b/ReactiveExtensions/operators/MergeMap.swift
@@ -2,12 +2,10 @@ import ReactiveSwift
 
 public extension SignalProtocol {
 
-  
   public func mergeMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
     return self.signal.flatMap(.merge, transform: f)
   }
 
-  
   public func mergeMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
     return self.signal.flatMap(.merge, transform: f)
   }
@@ -15,12 +13,10 @@ public extension SignalProtocol {
 
 public extension SignalProducerProtocol {
 
-  
   public func mergeMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
     return self.producer.flatMap(.merge, transform: f)
   }
 
-  
   public func mergeMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
     return self.producer.flatMap(.merge, transform: f)
   }

--- a/ReactiveExtensions/operators/MergeWith.swift
+++ b/ReactiveExtensions/operators/MergeWith.swift
@@ -9,7 +9,6 @@ public extension SignalProtocol {
 
    - returns: A merged signal.
    */
-  
   public func mergeWith (_ other: Signal<Value, Error>) -> Signal<Value, Error> {
     return Signal.merge([self.signal, other])
   }
@@ -24,7 +23,6 @@ public extension SignalProducerProtocol {
 
    - returns: A merged producer.
    */
-  
   public func mergeWith (_ other: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
     return SignalProducer<SignalProducer<Value, Error>, Error>([self.producer, other]).flatten(.merge)
   }

--- a/ReactiveExtensions/operators/MergeWith.swift
+++ b/ReactiveExtensions/operators/MergeWith.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Merges `self` with another signal.
@@ -9,13 +9,13 @@ public extension SignalType {
 
    - returns: A merged signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func mergeWith (other: Signal<Value, Error>) -> Signal<Value, Error> {
+  
+  public func mergeWith (_ other: Signal<Value, Error>) -> Signal<Value, Error> {
     return Signal.merge([self.signal, other])
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
   /**
    Merges `self` with another producer.
@@ -24,8 +24,8 @@ public extension SignalProducerType {
 
    - returns: A merged producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func mergeWith (other: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
-    return SignalProducer<SignalProducer<Value, Error>, Error>(values: [self.producer, other]).flatten(.Merge)
+  
+  public func mergeWith (_ other: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
+    return SignalProducer<SignalProducer<Value, Error>, Error>([self.producer, other]).flatten(.merge)
   }
 }

--- a/ReactiveExtensions/operators/ObserveForUI.swift
+++ b/ReactiveExtensions/operators/ObserveForUI.swift
@@ -7,7 +7,6 @@ public extension SignalProtocol {
 
    - returns: A new signal.
    */
-  
   public func observeForUI() -> Signal<Value, Error> {
     return self.signal.observe(on: UIScheduler())
   }
@@ -19,7 +18,6 @@ public extension SignalProtocol {
 
    - returns: A new signal.
    */
-  
   public func observeForControllerAction() -> Signal<Value, Error> {
     return self.signal.observe(on: QueueScheduler.main)
   }
@@ -32,7 +30,6 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer.
    */
-  
   public func observeForUI() -> SignalProducer<Value, Error> {
     return self.producer.observe(on: UIScheduler())
   }

--- a/ReactiveExtensions/operators/ObserveForUI.swift
+++ b/ReactiveExtensions/operators/ObserveForUI.swift
@@ -1,15 +1,15 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Transforms the signal into one that observes values on the UI thread.
 
    - returns: A new signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   public func observeForUI() -> Signal<Value, Error> {
-    return self.signal.observeOn(UIScheduler())
+    return self.signal.observe(on: UIScheduler())
   }
 
   /**
@@ -19,21 +19,21 @@ public extension SignalType {
 
    - returns: A new signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   public func observeForControllerAction() -> Signal<Value, Error> {
-    return self.signal.observeOn(QueueScheduler.mainQueueScheduler)
+    return self.signal.observe(on: QueueScheduler.main)
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
   /**
    Transforms the producer into one that observes values on the UI thread.
 
    - returns: A new producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
+  
   public func observeForUI() -> SignalProducer<Value, Error> {
-    return self.producer.observeOn(UIScheduler())
+    return self.producer.observe(on: UIScheduler())
   }
 }

--- a/ReactiveExtensions/operators/Scan.swift
+++ b/ReactiveExtensions/operators/Scan.swift
@@ -2,7 +2,6 @@ import ReactiveSwift
 
 public extension SignalProtocol {
 
-  
   /**
    Scans a signal without providing an initial value. The first emission of `self` will be emitted
    immediately, and subsequent emissions will be processed by the `combine` function.

--- a/ReactiveExtensions/operators/Scan.swift
+++ b/ReactiveExtensions/operators/Scan.swift
@@ -1,8 +1,8 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   /**
    Scans a signal without providing an initial value. The first emission of `self` will be emitted
    immediately, and subsequent emissions will be processed by the `combine` function.
@@ -11,7 +11,7 @@ public extension SignalType {
 
    - returns: A new signal.
    */
-  public func scan(combine: (Value, Value) -> Value) -> Signal<Value, Error> {
+  public func scan(_ combine: @escaping (Value, Value) -> Value) -> Signal<Value, Error> {
     return Signal { observer in
       var accumulated: Value? = nil
 

--- a/ReactiveExtensions/operators/SlidingWindow.swift
+++ b/ReactiveExtensions/operators/SlidingWindow.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Transform a signal into a window of previous values.
@@ -10,8 +10,8 @@ public extension SignalType {
 
    - returns: A new signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func slidingWindow (max max: Int, min: Int) -> Signal<[Value], Error> {
+  
+  public func slidingWindow (max: Int, min: Int) -> Signal<[Value], Error> {
     return signal
       .scan([Value]()) { window, value in
 
@@ -26,7 +26,7 @@ public extension SignalType {
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
   /**
    Transform a producer into a window of previous values.
@@ -36,8 +36,8 @@ public extension SignalProducerType {
 
    - returns: A new producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func slidingWindow (max max: Int, min: Int) -> SignalProducer<[Value], Error> {
+  
+  public func slidingWindow (max: Int, min: Int) -> SignalProducer<[Value], Error> {
     return lift { $0.slidingWindow(max: max, min: min) }
   }
 }

--- a/ReactiveExtensions/operators/SlidingWindow.swift
+++ b/ReactiveExtensions/operators/SlidingWindow.swift
@@ -10,7 +10,6 @@ public extension SignalProtocol {
 
    - returns: A new signal.
    */
-  
   public func slidingWindow (max: Int, min: Int) -> Signal<[Value], Error> {
     return signal
       .scan([Value]()) { window, value in
@@ -36,7 +35,6 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer.
    */
-  
   public func slidingWindow (max: Int, min: Int) -> SignalProducer<[Value], Error> {
     return lift { $0.slidingWindow(max: max, min: min) }
   }

--- a/ReactiveExtensions/operators/Sort.swift
+++ b/ReactiveExtensions/operators/Sort.swift
@@ -8,7 +8,6 @@ public extension SignalProtocol where Value: Sequence, Value.Iterator.Element: C
 
    - returns: The sorted signal.
    */
-  
   func sort() -> Signal<[Value.Iterator.Element], Error> {
     return self.signal.map { x in x.sorted() }
   }
@@ -38,7 +37,6 @@ public extension SignalProducerProtocol where Value: Sequence, Value.Iterator.El
 
    - returns: The sorted producer.
    */
-  
   func sort() -> SignalProducer<[Value.Iterator.Element], Error> {
     return lift { $0.sort() }
   }

--- a/ReactiveExtensions/operators/Sort.swift
+++ b/ReactiveExtensions/operators/Sort.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType where Value: SequenceType, Value.Generator.Element: Comparable {
+public extension SignalProtocol where Value: Sequence, Value.Iterator.Element: Comparable {
 
   /**
    Transforms a signal of sequences into a signal of ordered arrays by using the sequence element's
@@ -8,13 +8,13 @@ public extension SignalType where Value: SequenceType, Value.Generator.Element: 
 
    - returns: The sorted signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  func sort() -> Signal<[Value.Generator.Element], Error> {
-    return self.signal.map { x in x.sort() }
+  
+  func sort() -> Signal<[Value.Iterator.Element], Error> {
+    return self.signal.map { x in x.sorted() }
   }
 }
 
-public extension SignalType where Value: SequenceType {
+public extension SignalProtocol where Value: Sequence {
 
   /**
    Transforms a signal of sequences into a signal of ordered arrays by using the function passed in.
@@ -23,15 +23,15 @@ public extension SignalType where Value: SequenceType {
 
    - returns: The sorted signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func sort(isOrderedBefore: (Value.Generator.Element, Value.Generator.Element) -> Bool) ->
-    Signal<[Value.Generator.Element], Error> {
+  
+  public func sort(_ isOrderedBefore: @escaping (Value.Iterator.Element, Value.Iterator.Element) -> Bool) ->
+    Signal<[Value.Iterator.Element], Error> {
 
-    return self.signal.map { (x: Value) in x.sort(isOrderedBefore) }
+    return self.signal.map { (x: Value) in x.sorted(by: isOrderedBefore) }
   }
 }
 
-public extension SignalProducerType where Value: SequenceType, Value.Generator.Element: Comparable {
+public extension SignalProducerProtocol where Value: Sequence, Value.Iterator.Element: Comparable {
 
   /**
    Transforms a producer of sequences into a producer of ordered arrays by using the sequence element's
@@ -39,13 +39,13 @@ public extension SignalProducerType where Value: SequenceType, Value.Generator.E
 
    - returns: The sorted producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  func sort() -> SignalProducer<[Value.Generator.Element], Error> {
+  
+  func sort() -> SignalProducer<[Value.Iterator.Element], Error> {
     return lift { $0.sort() }
   }
 }
 
-public extension SignalProducerType where Value: SequenceType {
+public extension SignalProducerProtocol where Value: Sequence {
 
   /**
    Transforms a producer of sequences into a producer of ordered arrays by using the function passed in.
@@ -54,9 +54,9 @@ public extension SignalProducerType where Value: SequenceType {
 
    - returns: The sorted producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func sort(isOrderedBefore: (Value.Generator.Element, Value.Generator.Element) -> Bool) ->
-    SignalProducer<[Value.Generator.Element], Error> {
+  
+  public func sort(_ isOrderedBefore: @escaping (Value.Iterator.Element, Value.Iterator.Element) -> Bool) ->
+    SignalProducer<[Value.Iterator.Element], Error> {
 
     return lift { $0.sort(isOrderedBefore) }
   }

--- a/ReactiveExtensions/operators/Sort.swift
+++ b/ReactiveExtensions/operators/Sort.swift
@@ -23,7 +23,6 @@ public extension SignalProtocol where Value: Sequence {
 
    - returns: The sorted signal.
    */
-  
   public func sort(_ isOrderedBefore: @escaping (Value.Iterator.Element, Value.Iterator.Element) -> Bool) ->
     Signal<[Value.Iterator.Element], Error> {
 
@@ -54,7 +53,6 @@ public extension SignalProducerProtocol where Value: Sequence {
 
    - returns: The sorted producer.
    */
-  
   public func sort(_ isOrderedBefore: @escaping (Value.Iterator.Element, Value.Iterator.Element) -> Bool) ->
     SignalProducer<[Value.Iterator.Element], Error> {
 

--- a/ReactiveExtensions/operators/SwitchMap.swift
+++ b/ReactiveExtensions/operators/SwitchMap.swift
@@ -2,12 +2,10 @@ import ReactiveSwift
 
 public extension SignalProtocol {
 
-  
   public func switchMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
     return self.signal.flatMap(.latest, transform: f)
   }
 
-  
   public func switchMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
     return self.signal.flatMap(.latest, transform: f)
   }
@@ -15,12 +13,10 @@ public extension SignalProtocol {
 
 public extension SignalProducerProtocol {
 
-  
   public func switchMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
     return self.producer.flatMap(.latest, transform: f)
   }
 
-  
   public func switchMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
     return self.producer.flatMap(.latest, transform: f)
   }

--- a/ReactiveExtensions/operators/SwitchMap.swift
+++ b/ReactiveExtensions/operators/SwitchMap.swift
@@ -1,27 +1,27 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func switchMap <U> (f: Value -> SignalProducer<U, Error>) -> Signal<U, Error> {
-    return self.signal.flatMap(.Latest, transform: f)
+  
+  public func switchMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
+    return self.signal.flatMap(.latest, transform: f)
   }
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func switchMap <U> (f: Value -> Signal<U, Error>) -> Signal<U, Error> {
-    return self.signal.flatMap(.Latest, transform: f)
+  
+  public func switchMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
+    return self.signal.flatMap(.latest, transform: f)
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func switchMap <U> (f: Value -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
-    return self.producer.flatMap(.Latest, transform: f)
+  
+  public func switchMap <U> (_ f: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
+    return self.producer.flatMap(.latest, transform: f)
   }
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func switchMap <U> (f: Value -> Signal<U, Error>) -> SignalProducer<U, Error> {
-    return self.producer.flatMap(.Latest, transform: f)
+  
+  public func switchMap <U> (_ f: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
+    return self.producer.flatMap(.latest, transform: f)
   }
 }

--- a/ReactiveExtensions/operators/TakeUntil.swift
+++ b/ReactiveExtensions/operators/TakeUntil.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-extension SignalType {
+extension SignalProtocol {
 
   /**
    - parameter predicate: A function that determines when to terminate the signal.
@@ -8,12 +8,12 @@ extension SignalType {
    - returns: A signal that emits values up to, and including, when `predicate` returns true. Once
               `predicate` returns false the signal is completed.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func takeUntil(predicate: Value -> Bool) -> Signal<Value, Error> {
+  
+  public func takeUntil(_ predicate: @escaping (Value) -> Bool) -> Signal<Value, Error> {
     return Signal { observer in
       return self.observe { event in
-        if case let .Next(value) = event where predicate(value) {
-          observer.sendNext(value)
+        if case let .value(value) = event, predicate(value) {
+          observer.send(value: value)
           observer.sendCompleted()
         } else {
           observer.action(event)
@@ -23,7 +23,7 @@ extension SignalType {
   }
 }
 
-extension SignalProducerType {
+extension SignalProducerProtocol {
 
   /**
    - parameter predicate: A function that determines when to terminate the signal.
@@ -31,8 +31,8 @@ extension SignalProducerType {
    - returns: A signal that emits values up to, and including, when `predicate` returns false. Once
               `predicate` returns false the signal is completed.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func takeUntil(predicate: Value -> Bool) -> SignalProducer<Value, Error> {
+  
+  public func takeUntil(_ predicate: @escaping (Value) -> Bool) -> SignalProducer<Value, Error> {
     return lift { $0.takeUntil(predicate) }
   }
 }

--- a/ReactiveExtensions/operators/TakeUntil.swift
+++ b/ReactiveExtensions/operators/TakeUntil.swift
@@ -8,7 +8,6 @@ extension SignalProtocol {
    - returns: A signal that emits values up to, and including, when `predicate` returns true. Once
               `predicate` returns false the signal is completed.
    */
-  
   public func takeUntil(_ predicate: @escaping (Value) -> Bool) -> Signal<Value, Error> {
     return Signal { observer in
       return self.observe { event in
@@ -31,7 +30,6 @@ extension SignalProducerProtocol {
    - returns: A signal that emits values up to, and including, when `predicate` returns false. Once
               `predicate` returns false the signal is completed.
    */
-  
   public func takeUntil(_ predicate: @escaping (Value) -> Bool) -> SignalProducer<Value, Error> {
     return lift { $0.takeUntil(predicate) }
   }

--- a/ReactiveExtensions/operators/TakeWhen.swift
+++ b/ReactiveExtensions/operators/TakeWhen.swift
@@ -9,7 +9,6 @@ public extension SignalProtocol {
 
    - returns: A new signal.
    */
-  
   public func takeWhen <U> (_ other: Signal<U, Error>) -> Signal<Value, Error> {
     return other.withLatestFrom(self.signal).map { tuple in tuple.1 }
   }
@@ -36,7 +35,6 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer.
    */
-  
   public func takeWhen <U> (_ other: Signal<U, Error>) -> Signal<Value, Error> {
     return other.withLatestFrom(self.producer).map { $0.1 }
   }

--- a/ReactiveExtensions/operators/TakeWhen.swift
+++ b/ReactiveExtensions/operators/TakeWhen.swift
@@ -1,6 +1,6 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Emits the most recent value of `self` when `other` emits.
@@ -9,12 +9,12 @@ public extension SignalType {
 
    - returns: A new signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func takeWhen <U> (other: Signal<U, Error>) -> Signal<Value, Error> {
+  
+  public func takeWhen <U> (_ other: Signal<U, Error>) -> Signal<Value, Error> {
     return other.withLatestFrom(self.signal).map { tuple in tuple.1 }
   }
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   /**
    Emits the most recent value of `self` and `other` when `other` emits.
 
@@ -22,12 +22,12 @@ public extension SignalType {
 
    - returns: A new signal.
    */
-  public func takePairWhen <U> (other: Signal<U, Error>) -> Signal<(Value, U), Error> {
+  public func takePairWhen <U> (_ other: Signal<U, Error>) -> Signal<(Value, U), Error> {
     return other.withLatestFrom(self.signal).map { ($0.1, $0.0) }
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
   /**
    Emits the most recent value of `self` when `other` emits.
@@ -36,12 +36,12 @@ public extension SignalProducerType {
 
    - returns: A new producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func takeWhen <U> (other: Signal<U, Error>) -> Signal<Value, Error> {
+  
+  public func takeWhen <U> (_ other: Signal<U, Error>) -> Signal<Value, Error> {
     return other.withLatestFrom(self.producer).map { $0.1 }
   }
 
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
+  
   /**
    Emits the most recent value of `self` and `other` when `other` emits.
 
@@ -49,7 +49,7 @@ public extension SignalProducerType {
 
    - returns: A new producer.
    */
-  public func takePairWhen <U> (other: Signal<U, Error>) -> Signal<(Value, U), Error> {
+  public func takePairWhen <U> (_ other: Signal<U, Error>) -> Signal<(Value, U), Error> {
     return other.withLatestFrom(self.producer).map { ($0.1, $0.0) }
   }
 }

--- a/ReactiveExtensions/operators/TakeWhen.swift
+++ b/ReactiveExtensions/operators/TakeWhen.swift
@@ -13,7 +13,6 @@ public extension SignalProtocol {
     return other.withLatestFrom(self.signal).map { tuple in tuple.1 }
   }
 
-  
   /**
    Emits the most recent value of `self` and `other` when `other` emits.
 
@@ -39,7 +38,6 @@ public extension SignalProducerProtocol {
     return other.withLatestFrom(self.producer).map { $0.1 }
   }
 
-  
   /**
    Emits the most recent value of `self` and `other` when `other` emits.
 

--- a/ReactiveExtensions/operators/Uncollect.swift
+++ b/ReactiveExtensions/operators/Uncollect.swift
@@ -1,23 +1,23 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType where Value: SequenceType {
+public extension SignalProtocol where Value: Sequence {
   /**
    Transforms a signal of sequences into a signal of elements by emitting all elements of each sequence.
 
    - returns: A new signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
-  public func uncollect() -> Signal<Value.Generator.Element, Error> {
-    return Signal<Value.Generator.Element, Error> { observer in
+  
+  public func uncollect() -> Signal<Value.Iterator.Element, Error> {
+    return Signal<Value.Iterator.Element, Error> { observer in
       return self.observe { event in
         switch event {
-        case let .Next(sequence):
-          sequence.forEach(observer.sendNext)
-        case let .Failed(error):
-          observer.sendFailed(error)
-        case .Completed:
+        case let .value(sequence):
+          sequence.forEach(observer.send(value:))
+        case let .failed(error):
+          observer.send(error: error)
+        case .completed:
           observer.sendCompleted()
-        case .Interrupted:
+        case .interrupted:
           observer.sendInterrupted()
         }
       }
@@ -25,14 +25,14 @@ public extension SignalType where Value: SequenceType {
   }
 }
 
-public extension SignalProducerType where Value: SequenceType {
+public extension SignalProducerProtocol where Value: Sequence {
   /**
    Transforms a producer of sequences into a producer of elements by emitting all elements of each sequence.
 
    - returns: A new producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
-  public func uncollect() -> SignalProducer<Value.Generator.Element, Error> {
+  
+  public func uncollect() -> SignalProducer<Value.Iterator.Element, Error> {
     return lift { $0.uncollect() }
   }
 }

--- a/ReactiveExtensions/operators/Uncollect.swift
+++ b/ReactiveExtensions/operators/Uncollect.swift
@@ -6,7 +6,6 @@ public extension SignalProtocol where Value: Sequence {
 
    - returns: A new signal.
    */
-  
   public func uncollect() -> Signal<Value.Iterator.Element, Error> {
     return Signal<Value.Iterator.Element, Error> { observer in
       return self.observe { event in
@@ -31,7 +30,6 @@ public extension SignalProducerProtocol where Value: Sequence {
 
    - returns: A new producer.
    */
-  
   public func uncollect() -> SignalProducer<Value.Iterator.Element, Error> {
     return lift { $0.uncollect() }
   }

--- a/ReactiveExtensions/operators/Values.swift
+++ b/ReactiveExtensions/operators/Values.swift
@@ -1,16 +1,16 @@
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 
-extension SignalType where Value: EventType, Error == NoError {
+extension SignalProtocol where Value: EventProtocol, Error == NoError {
   /**
    - returns: A signal of values of `Next` events from a materialized signal.
    */
   public func values() -> Signal<Value.Value, NoError> {
-    return self.signal.map { $0.event.value }.ignoreNil()
+    return self.signal.map { $0.event.value }.skipNil()
   }
 }
 
-extension SignalProducerType where Value: EventType, Error == NoError {
+extension SignalProducerProtocol where Value: EventProtocol, Error == NoError {
   /**
    - returns: A producer of values of `Next` events from a materialized signal.
    */

--- a/ReactiveExtensions/operators/WithLatestFrom.swift
+++ b/ReactiveExtensions/operators/WithLatestFrom.swift
@@ -54,7 +54,6 @@ public extension SignalProtocol {
     }
   }
 
-  
   /**
    Transforms the signal into one that emits the most recent values of `self` and `other` only when `self`
    emits.

--- a/ReactiveExtensions/operators/WithLatestFrom.swift
+++ b/ReactiveExtensions/operators/WithLatestFrom.swift
@@ -1,8 +1,8 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   /**
    Transforms the signal into one that emits the most recent values of `self` and `other` only when `self`
    emits.
@@ -11,7 +11,7 @@ public extension SignalType {
 
    - returns: A new signal.
    */
-  public func withLatestFrom <U, OtherError: ErrorType> (other: Signal<U, OtherError>) ->
+  public func withLatestFrom <U, OtherError: Swift.Error> (_ other: Signal<U, OtherError>) ->
     Signal<(Value, U), OtherError> {
 
     return Signal { observer in
@@ -23,28 +23,28 @@ public extension SignalType {
 
       disposable += other.observe { event in
         switch event {
-        case let .Next(value):
+        case let .value(value):
           lock.lock()
           latestValue = value
           lock.unlock()
-        case let .Failed(error):
-          observer.sendFailed(error)
-        case .Completed:
+        case let .failed(error):
+          observer.send(error: error)
+        case .completed:
           observer.sendCompleted()
-        case .Interrupted:
+        case .interrupted:
           observer.sendInterrupted()
         }
       }
 
       disposable += self.signal.observe { event in
         switch event {
-        case let .Next(value):
+        case let .value(value):
           lock.lock()
           if let latestValue = latestValue {
-            observer.sendNext((value, latestValue))
+            observer.send(value: (value, latestValue))
           }
           lock.unlock()
-        case .Failed, .Completed, .Interrupted:
+        case .failed, .completed, .interrupted:
           // don't fail, complete or interrupt when the other does
           break
         }
@@ -54,7 +54,7 @@ public extension SignalType {
     }
   }
 
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   /**
    Transforms the signal into one that emits the most recent values of `self` and `other` only when `self`
    emits.
@@ -63,7 +63,7 @@ public extension SignalType {
 
    - returns: A new signal.
    */
-  public func withLatestFrom <U, OtherError: ErrorType> (other: SignalProducer<U, OtherError>) ->
+  public func withLatestFrom <U, OtherError: Swift.Error> (_ other: SignalProducer<U, OtherError>) ->
     Signal<(Value, U), OtherError> {
 
     return Signal { observer in
@@ -75,28 +75,28 @@ public extension SignalType {
 
       disposable += other.start { event in
         switch event {
-        case let .Next(value):
+        case let .value(value):
           lock.lock()
           latestValue = value
           lock.unlock()
-        case let .Failed(error):
-          observer.sendFailed(error)
-        case .Completed:
+        case let .failed(error):
+          observer.send(error: error)
+        case .completed:
           observer.sendCompleted()
-        case .Interrupted:
+        case .interrupted:
           observer.sendInterrupted()
         }
       }
 
       disposable += self.signal.observe { event in
         switch event {
-        case let .Next(value):
+        case let .value(value):
           lock.lock()
           if let latestValue = latestValue {
-            observer.sendNext((value, latestValue))
+            observer.send(value: (value, latestValue))
           }
           lock.unlock()
-        case .Failed, .Completed, .Interrupted:
+        case .failed, .completed, .interrupted:
           // don't fail, complete or interrupt when the other does
           break
         }

--- a/ReactiveExtensions/operators/WithLatestFrom.swift
+++ b/ReactiveExtensions/operators/WithLatestFrom.swift
@@ -2,7 +2,6 @@ import ReactiveSwift
 
 public extension SignalProtocol {
 
-  
   /**
    Transforms the signal into one that emits the most recent values of `self` and `other` only when `self`
    emits.

--- a/ReactiveExtensions/operators/WrapInOptional.swift
+++ b/ReactiveExtensions/operators/WrapInOptional.swift
@@ -7,7 +7,6 @@ public extension SignalProtocol {
 
    - returns: A new signal.
    */
-  
   public func wrapInOptional() -> Signal<Value?, Error> {
     return signal.map { x in Optional(x) }
   }
@@ -20,7 +19,6 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer.
    */
-  
   public func wrapInOptional() -> SignalProducer<Value?, Error> {
     return lift { $0.wrapInOptional() }
   }

--- a/ReactiveExtensions/operators/WrapInOptional.swift
+++ b/ReactiveExtensions/operators/WrapInOptional.swift
@@ -19,6 +19,7 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer.
    */
+  @available(*, deprecated, message: "Use ReactiveSwift’s `optionalize` instead.")
   public func wrapInOptional() -> SignalProducer<Value?, Error> {
     return lift { $0.wrapInOptional() }
   }

--- a/ReactiveExtensions/operators/WrapInOptional.swift
+++ b/ReactiveExtensions/operators/WrapInOptional.swift
@@ -19,7 +19,6 @@ public extension SignalProducerProtocol {
 
    - returns: A new producer.
    */
-  @available(*, deprecated, message: "Use ReactiveSwift’s `optionalize` instead.")
   public func wrapInOptional() -> SignalProducer<Value?, Error> {
     return lift { $0.wrapInOptional() }
   }

--- a/ReactiveExtensions/operators/WrapInOptional.swift
+++ b/ReactiveExtensions/operators/WrapInOptional.swift
@@ -1,26 +1,26 @@
-import ReactiveCocoa
+import ReactiveSwift
 
-public extension SignalType {
+public extension SignalProtocol {
 
   /**
    Transforms a signal of `Value`s into a signal of `Optional<Value>`s by simply wrapping each emission.
 
    - returns: A new signal.
    */
-  @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+  
   public func wrapInOptional() -> Signal<Value?, Error> {
     return signal.map { x in Optional(x) }
   }
 }
 
-public extension SignalProducerType {
+public extension SignalProducerProtocol {
 
   /**
    Transforms a producer of `Value`s into a producer of `Optional<Value>`s by simply wrapping each emission.
 
    - returns: A new producer.
    */
-  @warn_unused_result(message="Did you forget to call `start` on the producer?")
+  
   public func wrapInOptional() -> SignalProducer<Value?, Error> {
     return lift { $0.wrapInOptional() }
   }

--- a/ReactiveExtensionsTests/TestHelpers/Event-Extensions.swift
+++ b/ReactiveExtensionsTests/TestHelpers/Event-Extensions.swift
@@ -1,29 +1,24 @@
-import ReactiveCocoa
+import ReactiveSwift
 
 internal extension Event {
-  internal var isNext: Bool {
-    if case .Next = self {
-      return true
-    }
-    return false
-  }
 
-  internal var isCompleted: Bool {
-    if case .Completed = self {
+  @available(*, deprecated, message: "Rename this to `isValue`.")
+  internal var isNext: Bool {
+    if case .value = self {
       return true
     }
     return false
   }
 
   internal var isFailed: Bool {
-    if case .Failed = self {
+    if case .failed = self {
       return true
     }
     return false
   }
 
   internal var isInterrupted: Bool {
-    if case .Interrupted = self {
+    if case .interrupted = self {
       return true
     }
     return false

--- a/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
+++ b/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 
 /**
  A `TestObserver` is a wrapper around an `Observer` that saves all events to an internal array so that
@@ -16,16 +16,16 @@ import ReactiveCocoa
  test.assertValues([1, 2, 3])
  ```
  */
-internal final class TestObserver <Value, Error: ErrorType> {
+internal final class TestObserver <Value, Error: Swift.Error> {
 
-  internal private(set) var events: [Event<Value, Error>] = []
-  internal private(set) var observer: Observer<Value, Error>!
+  internal fileprivate(set) var events: [Event<Value, Error>] = []
+  internal fileprivate(set) var observer: Observer<Value, Error>!
 
   internal init() {
     self.observer = Observer<Value, Error>(action)
   }
 
-  private func action(event: Event<Value, Error>) -> () {
+  fileprivate func action(_ event: Event<Value, Error>) -> () {
     self.events.append(event)
   }
 
@@ -64,59 +64,59 @@ internal final class TestObserver <Value, Error: ErrorType> {
     return self.events.filter { $0.isInterrupted }.count > 0
   }
 
-  internal func assertDidComplete(message: String = "Should have completed.",
+  internal func assertDidComplete(_ message: String = "Should have completed.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didComplete, message, file: file, line: line)
   }
 
-  internal func assertDidFail(message: String = "Should have failed.",
+  internal func assertDidFail(_ message: String = "Should have failed.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didFail, message, file: file, line: line)
   }
 
-  internal func assertDidNotFail(message: String = "Should not have failed.",
+  internal func assertDidNotFail(_ message: String = "Should not have failed.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertFalse(self.didFail, message, file: file, line: line)
   }
 
-  internal func assertDidInterrupt(message: String = "Should have failed.",
+  internal func assertDidInterrupt(_ message: String = "Should have failed.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didInterrupt, message, file: file, line: line)
   }
 
-  internal func assertDidNotInterrupt(message: String = "Should not have failed.",
+  internal func assertDidNotInterrupt(_ message: String = "Should not have failed.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertFalse(self.didInterrupt, message, file: file, line: line)
   }
 
-  internal func assertDidNotComplete(message: String = "Should not have completed",
+  internal func assertDidNotComplete(_ message: String = "Should not have completed",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertFalse(self.didComplete, message, file: file, line: line)
   }
 
-  internal func assertDidEmitValue(message: String = "Should have emitted at least one value.",
+  internal func assertDidEmitValue(_ message: String = "Should have emitted at least one value.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssert(self.values.count > 0, message, file: file, line: line)
   }
 
-  internal func assertDidNotEmitValue(message: String = "Should not have emitted any values.",
+  internal func assertDidNotEmitValue(_ message: String = "Should not have emitted any values.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(0, self.values.count, message, file: file, line: line)
   }
 
   internal func assertDidTerminate(
-    message: String = "Should have terminated, i.e. completed/failed/interrupted.",
+    _ message: String = "Should have terminated, i.e. completed/failed/interrupted.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didFail || self.didComplete || self.didInterrupt, message, file: file, line: line)
   }
 
   internal func assertDidNotTerminate(
-    message: String = "Should not have terminated, i.e. completed/failed/interrupted.",
+    _ message: String = "Should not have terminated, i.e. completed/failed/interrupted.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(!self.didFail && !self.didComplete && !self.didInterrupt, message, file: file, line: line)
   }
 
-  internal func assertValueCount(count: Int, _ message: String? = nil,
+  internal func assertValueCount(_ count: Int, _ message: String? = nil,
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(count, self.values.count, message ?? "Should have emitted \(count) values",
         file: file, line: line)
@@ -124,28 +124,28 @@ internal final class TestObserver <Value, Error: ErrorType> {
 }
 
 extension TestObserver where Value: Equatable {
-  internal func assertValue(value: Value, _ message: String? = nil,
+  internal func assertValue(_ value: Value, _ message: String? = nil,
                             file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
     XCTAssertEqual(value, self.lastValue, message ?? "A single value of \(value) should have been emitted",
                    file: file, line: line)
   }
 
-  internal func assertLastValue(value: Value, _ message: String? = nil,
+  internal func assertLastValue(_ value: Value, _ message: String? = nil,
                             file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(value, self.lastValue, message ?? "Last emitted value is equal to \(value).",
                    file: file, line: line)
   }
 
-  internal func assertValues(values: [Value], _ message: String = "",
+  internal func assertValues(_ values: [Value], _ message: String = "",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(values, self.values, message, file: file, line: line)
   }
 }
 
-extension TestObserver where Value: ReactiveCocoa.OptionalType, Value.Wrapped: Equatable {
+extension TestObserver where Value: ReactiveSwift.OptionalProtocol, Value.Wrapped: Equatable {
 
-  internal func assertValue(value: Value, _ message: String? = nil,
+  internal func assertValue(_ value: Value, _ message: String? = nil,
                             file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
     XCTAssertEqual(value.optional, self.lastValue?.optional,
@@ -153,22 +153,22 @@ extension TestObserver where Value: ReactiveCocoa.OptionalType, Value.Wrapped: E
                    file: file, line: line)
   }
 
-  internal func assertLastValue(value: Value, _ message: String? = nil,
+  internal func assertLastValue(_ value: Value, _ message: String? = nil,
                                 file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(value.optional, self.lastValue?.optional,
                    message ?? "Last emitted value is equal to \(value).",
                    file: file, line: line)
   }
 
-  internal func assertValues(values: [Value], _ message: String = "",
+  internal func assertValues(_ values: [Value], _ message: String = "",
                              file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(values, self.values, message, file: file, line: line)
   }
 }
 
-extension TestObserver where Value: SequenceType, Value.Generator.Element: Equatable {
+extension TestObserver where Value: Sequence, Value.Iterator.Element: Equatable {
 
-  internal func assertValue(value: Value, _ message: String? = nil,
+  internal func assertValue(_ value: Value, _ message: String? = nil,
                             file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
     XCTAssertEqual(Array(value), self.lastValue.map(Array.init) ?? [],
@@ -176,14 +176,14 @@ extension TestObserver where Value: SequenceType, Value.Generator.Element: Equat
                    file: file, line: line)
   }
 
-  internal func assertLastValue(value: Value, _ message: String? = nil,
+  internal func assertLastValue(_ value: Value, _ message: String? = nil,
                             file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(Array(value), self.lastValue.map(Array.init) ?? [],
                    message ?? "Last emitted value is equal to \(value).",
                    file: file, line: line)
   }
 
-  internal func assertValues(values: [[Value.Generator.Element]], _ message: String = "",
+  internal func assertValues(_ values: [[Value.Iterator.Element]], _ message: String = "",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(Array(values), Array(self.values.map(Array.init)), message, file: file, line: line)
   }
@@ -191,7 +191,7 @@ extension TestObserver where Value: SequenceType, Value.Generator.Element: Equat
 }
 
 extension TestObserver where Error: Equatable {
-  internal func assertFailed(expectedError: Error, message: String = "",
+  internal func assertFailed(_ expectedError: Error, message: String = "",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(expectedError, self.failedError, message, file: file, line: line)
   }

--- a/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
+++ b/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
@@ -18,14 +18,14 @@ import ReactiveSwift
  */
 internal final class TestObserver <Value, Error: Swift.Error> {
 
-  internal fileprivate(set) var events: [Event<Value, Error>] = []
-  internal fileprivate(set) var observer: Observer<Value, Error>!
+  internal private(set) var events: [Event<Value, Error>] = []
+  internal private(set) var observer: Observer<Value, Error>!
 
   internal init() {
     self.observer = Observer<Value, Error>(action)
   }
 
-  fileprivate func action(_ event: Event<Value, Error>) -> () {
+  private func action(_ event: Event<Value, Error>) -> () {
     self.events.append(event)
   }
 

--- a/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
+++ b/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
@@ -25,7 +25,7 @@ internal final class TestObserver <Value, Error: Swift.Error> {
     self.observer = Observer<Value, Error>(action)
   }
 
-  private func action(_ event: Event<Value, Error>) -> () {
+  private func action(_ event: Event<Value, Error>) -> Void {
     self.events.append(event)
   }
 

--- a/ReactiveExtensionsTests/TestHelpers/XCTAssert-Extensions.swift
+++ b/ReactiveExtensionsTests/TestHelpers/XCTAssert-Extensions.swift
@@ -1,9 +1,9 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 
 // Assert equality between two doubly nested arrays of equatables.
-internal func XCTAssertEqual<T: Equatable>(@autoclosure expression1: () -> [[T]],
-  @autoclosure _ expression2: () -> [[T]], _ message: String = "",
+internal func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () -> [[T]],
+  _ expression2: @autoclosure () -> [[T]], _ message: String = "",
                  file: StaticString = #file, line: UInt = #line) {
 
     let lhs = expression1()
@@ -17,9 +17,9 @@ internal func XCTAssertEqual<T: Equatable>(@autoclosure expression1: () -> [[T]]
 }
 
 // Assert equality between arrays of optionals of equatables.
-internal func XCTAssertEqual <T: ReactiveCocoa.OptionalType where T.Wrapped: Equatable>
-  (expression1: [T], _ expression2: [T], _ message: String = "",
-   file: StaticString = #file, line: UInt = #line) {
+internal func XCTAssertEqual <T: ReactiveSwift.OptionalProtocol>
+  (_ expression1: [T], _ expression2: [T], _ message: String = "",
+   file: StaticString = #file, line: UInt = #line) where T.Wrapped: Equatable {
 
   XCTAssertEqual(
     expression1.count, expression2.count,

--- a/ReactiveExtensionsTests/TestHelpers/XCTestCase+Async.swift
+++ b/ReactiveExtensionsTests/TestHelpers/XCTestCase+Async.swift
@@ -3,15 +3,15 @@ import XCTest
 extension XCTestCase {
   internal func async(expect description: String = "async",
                              timeout: Double = 5,
-                             block: (() -> Void) -> Void) {
-    let expectation = expectationWithDescription(description)
-    dispatch_async(dispatch_get_main_queue()) {
+                             block: @escaping (() -> Void) -> Void) {
+    let expectation = self.expectation(description: description)
+    DispatchQueue.main.async {
       block(expectation.fulfill)
     }
-    waitForExpectationsWithTimeout(timeout, handler: nil)
+    waitForExpectations(timeout: timeout, handler: nil)
   }
 
-  internal func eventually(@autoclosure(escaping) assertion: () -> Void) {
+  internal func eventually( _ assertion: @autoclosure @escaping () -> Void) {
     async { done in
       assertion()
       done()

--- a/ReactiveExtensionsTests/UIKit/NSLayoutConstraintTests.swift
+++ b/ReactiveExtensionsTests/UIKit/NSLayoutConstraintTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -12,13 +12,13 @@ final class NSLayoutConstraintTests: XCTestCase {
     let (signal, observer) = Signal<CGFloat, NoError>.pipe()
     constraint.rac.constant = signal
 
-    observer.sendNext(1.0)
+    observer.send(value: 1.0)
     eventually(XCTAssertEqual(1.0, self.constraint.constant))
 
-    observer.sendNext(0.0)
+    observer.send(value: 0.0)
     eventually(XCTAssertEqual(0.0, self.constraint.constant))
 
-    observer.sendNext(-1.0)
+    observer.send(value: -1.0)
     eventually(XCTAssertEqual(-1.0, self.constraint.constant))
   }
 }

--- a/ReactiveExtensionsTests/UIKit/UIActivityIndicatorTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIActivityIndicatorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -12,13 +12,13 @@ final class UIActivityIndicatorTests: XCTestCase {
     let (signal, observer) = Signal<Bool, NoError>.pipe()
     indicator.rac.animating = signal
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.indicator.isAnimating()))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.indicator.isAnimating))
 
-    observer.sendNext(false)
-    eventually(XCTAssertFalse(self.indicator.isAnimating()))
+    observer.send(value: false)
+    eventually(XCTAssertFalse(self.indicator.isAnimating))
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.indicator.isAnimating()))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.indicator.isAnimating))
   }
 }

--- a/ReactiveExtensionsTests/UIKit/UIBarButtonItemTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIBarButtonItemTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -12,13 +12,13 @@ final class UIBarButtonItemTests: XCTestCase {
     let (signal, observer) = Signal<Bool, NoError>.pipe()
     barButtonItem.rac.enabled = signal
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.barButtonItem.enabled))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.barButtonItem.isEnabled))
 
-    observer.sendNext(false)
-    eventually(XCTAssertFalse(self.barButtonItem.enabled))
+    observer.send(value: false)
+    eventually(XCTAssertFalse(self.barButtonItem.isEnabled))
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.barButtonItem.enabled))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.barButtonItem.isEnabled))
   }
 }

--- a/ReactiveExtensionsTests/UIKit/UIButtonTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIButtonTests.swift
@@ -6,7 +6,7 @@ import UIKit
 @testable import ReactiveExtensions_TestHelpers
 
 internal final class UIButtonTests: XCTestCase {
-  fileprivate let button = UIButton()
+  private let button = UIButton()
 
   func testTitle() {
     let (signal, observer) = Signal<String, NoError>.pipe()

--- a/ReactiveExtensionsTests/UIKit/UIButtonTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIButtonTests.swift
@@ -1,24 +1,24 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers
 
 internal final class UIButtonTests: XCTestCase {
-  private let button = UIButton()
+  fileprivate let button = UIButton()
 
   func testTitle() {
     let (signal, observer) = Signal<String, NoError>.pipe()
     button.rac.title = signal
 
-    observer.sendNext("Hello")
-    eventually(XCTAssertEqual("Hello", self.button.titleForState(.Normal)))
+    observer.send(value: "Hello")
+    eventually(XCTAssertEqual("Hello", self.button.title(for: .normal)))
 
-    observer.sendNext("Hello World")
-    eventually(XCTAssertEqual("Hello World", self.button.titleForState(.Normal)))
+    observer.send(value: "Hello World")
+    eventually(XCTAssertEqual("Hello World", self.button.title(for: .normal)))
 
-    observer.sendNext("")
-    eventually(XCTAssertEqual("", self.button.titleForState(.Normal)))
+    observer.send(value: "")
+    eventually(XCTAssertEqual("", self.button.title(for: .normal)))
   }
 }

--- a/ReactiveExtensionsTests/UIKit/UIControlTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIControlTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -13,27 +13,27 @@ final class UIControlTests: XCTestCase {
     let (signal, observer) = Signal<Bool, NoError>.pipe()
     control.rac.enabled = signal
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.control.enabled))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.control.isEnabled))
 
-    observer.sendNext(false)
-    eventually(XCTAssertFalse(self.control.enabled))
+    observer.send(value: false)
+    eventually(XCTAssertFalse(self.control.isEnabled))
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.control.enabled))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.control.isEnabled))
   }
 
   func testSelected() {
     let (signal, observer) = Signal<Bool, NoError>.pipe()
     control.rac.selected = signal
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.control.selected))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.control.isSelected))
 
-    observer.sendNext(false)
-    eventually(XCTAssertFalse(self.control.selected))
+    observer.send(value: false)
+    eventually(XCTAssertFalse(self.control.isSelected))
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.control.selected))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.control.isSelected))
   }
 }

--- a/ReactiveExtensionsTests/UIKit/UILabelTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UILabelTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -12,10 +12,10 @@ final class UILabelTests: XCTestCase {
     let (signal, observer) = Signal<String, NoError>.pipe()
     label.rac.text = signal
 
-    observer.sendNext("The future")
+    observer.send(value: "The future")
     eventually(XCTAssertEqual("The future", self.label.text))
 
-    observer.sendNext("")
+    observer.send(value: "")
     eventually(XCTAssertEqual("", self.label.text))
   }
 
@@ -23,9 +23,9 @@ final class UILabelTests: XCTestCase {
     let (signal, observer) = Signal<UIFont, NoError>.pipe()
     label.rac.font = signal
 
-    let font = UIFont.systemFontOfSize(16.0)
+    let font = UIFont.systemFont(ofSize: 16.0)
 
-    observer.sendNext(font)
+    observer.send(value: font)
     eventually(XCTAssertEqual(font, self.label.font))
   }
 
@@ -33,9 +33,9 @@ final class UILabelTests: XCTestCase {
     let (signal, observer) = Signal<UIColor, NoError>.pipe()
     label.rac.textColor = signal
 
-    let color = UIColor.redColor()
+    let color = UIColor.red
 
-    observer.sendNext(color)
+    observer.send(value: color)
     eventually(XCTAssertEqual(color, self.label.textColor))
   }
 }

--- a/ReactiveExtensionsTests/UIKit/UIRefreshControlTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIRefreshControlTests.swift
@@ -1,6 +1,6 @@
 #if os(iOS)
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -13,14 +13,14 @@ final class UIRefreshControlTests: XCTestCase {
     let (signal, observer) = Signal<Bool, NoError>.pipe()
     control.rac.refreshing = signal
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.control.refreshing))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.control.isRefreshing))
 
-    observer.sendNext(false)
-    eventually(XCTAssertFalse(self.control.refreshing))
+    observer.send(value: false)
+    eventually(XCTAssertFalse(self.control.isRefreshing))
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.control.refreshing))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.control.isRefreshing))
   }
 }
 #endif

--- a/ReactiveExtensionsTests/UIKit/UIResponderTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIResponderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -22,10 +22,10 @@ final class UIResponderTests: XCTestCase {
     let (signal, observer) = Signal<(), NoError>.pipe()
     responder.rac.becomeFirstResponder = signal
 
-    eventually(XCTAssertFalse(self.responder.isFirstResponder()))
+    eventually(XCTAssertFalse(self.responder.isFirstResponder))
 
-    observer.sendNext()
-    eventually(XCTAssertTrue(self.responder.isFirstResponder()))
+    observer.send(value: ())
+    eventually(XCTAssertTrue(self.responder.isFirstResponder))
   }
 
   func testIsFirstResponder() {
@@ -33,15 +33,15 @@ final class UIResponderTests: XCTestCase {
     let (signal, observer) = Signal<Bool, NoError>.pipe()
     responder.rac.isFirstResponder = signal
 
-    eventually(XCTAssertFalse(self.responder.isFirstResponder()))
+    eventually(XCTAssertFalse(self.responder.isFirstResponder))
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.responder.isFirstResponder()))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.responder.isFirstResponder))
 
-    observer.sendNext(false)
-    eventually(XCTAssertFalse(self.responder.isFirstResponder()))
+    observer.send(value: false)
+    eventually(XCTAssertFalse(self.responder.isFirstResponder))
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.responder.isFirstResponder()))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.responder.isFirstResponder))
   }
 }

--- a/ReactiveExtensionsTests/UIKit/UISwitchTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UISwitchTests.swift
@@ -1,6 +1,6 @@
 #if os(iOS)
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -13,14 +13,14 @@ internal final class UISwitchTests: XCTestCase {
     let (signal, observer) = Signal<Bool, NoError>.pipe()
     uiSwitch.rac.on = signal
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.uiSwitch.on))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.uiSwitch.isOn))
 
-    observer.sendNext(false)
-    eventually(XCTAssertFalse(self.uiSwitch.on))
+    observer.send(value: false)
+    eventually(XCTAssertFalse(self.uiSwitch.isOn))
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.uiSwitch.on))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.uiSwitch.isOn))
   }
 }
 #endif

--- a/ReactiveExtensionsTests/UIKit/UITextFieldTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UITextFieldTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -12,10 +12,10 @@ final class UITextFieldTests: XCTestCase {
     let (signal, observer) = Signal<String, NoError>.pipe()
     textField.rac.text = signal
 
-    observer.sendNext("The future")
+    observer.send(value: "The future")
     eventually(XCTAssertEqual("The future", self.textField.text))
 
-    observer.sendNext("")
+    observer.send(value: "")
     eventually(XCTAssertEqual("", self.textField.text))
   }
 }

--- a/ReactiveExtensionsTests/UIKit/UITextViewTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UITextViewTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -12,10 +12,10 @@ final class UITextViewTests: XCTestCase {
     let (signal, observer) = Signal<String, NoError>.pipe()
     textView.rac.text = signal
 
-    observer.sendNext("The future")
+    observer.send(value: "The future")
     eventually(XCTAssertEqual("The future", self.textView.text))
 
-    observer.sendNext("")
+    observer.send(value: "")
     eventually(XCTAssertEqual("", self.textView.text))
   }
 }

--- a/ReactiveExtensionsTests/UIKit/UIViewTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIViewTests.swift
@@ -65,7 +65,7 @@ final class UIViewTests: XCTestCase {
     eventually(XCTAssertTrue(self.view.isHidden))
   }
 
-  fileprivate final class MockView: UIView {
+  private final class MockView: UIView {
     var callback: () -> Void = {}
 
     override var alpha: CGFloat {

--- a/ReactiveExtensionsTests/UIKit/UIViewTests.swift
+++ b/ReactiveExtensionsTests/UIKit/UIViewTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 import UIKit
@@ -13,10 +13,10 @@ final class UIViewTests: XCTestCase {
     let (signal, observer) = Signal<CGFloat, NoError>.pipe()
     view.rac.alpha = signal
 
-    observer.sendNext(0.0)
+    observer.send(value: 0.0)
     eventually(XCTAssertEqual(0.0, self.view.alpha))
 
-    observer.sendNext(0.5)
+    observer.send(value: 0.5)
     eventually(XCTAssertEqual(0.5, self.view.alpha))
   }
 
@@ -24,11 +24,11 @@ final class UIViewTests: XCTestCase {
     let (signal, observer) = Signal<UIColor, NoError>.pipe()
     view.rac.backgroundColor = signal
 
-    observer.sendNext(.redColor())
-    eventually(XCTAssertEqual(.redColor(), self.view.backgroundColor))
+    observer.send(value: .red)
+    eventually(XCTAssertEqual(.red, self.view.backgroundColor))
 
-    observer.sendNext(.greenColor())
-    eventually(XCTAssertEqual(.greenColor(), self.view.backgroundColor))
+    observer.send(value: .green)
+    eventually(XCTAssertEqual(.green, self.view.backgroundColor))
   }
 
   func testEndEditing() {
@@ -45,27 +45,27 @@ final class UIViewTests: XCTestCase {
 
     view.rac.endEditing = signal
 
-    eventually(XCTAssertTrue(view.isFirstResponder()))
+    eventually(XCTAssertTrue(view.isFirstResponder))
 
-    observer.sendNext()
-    eventually(XCTAssertFalse(view.isFirstResponder()))
+    observer.send(value: ())
+    eventually(XCTAssertFalse(view.isFirstResponder))
   }
 
   func testHidden() {
     let (signal, observer) = Signal<Bool, NoError>.pipe()
     view.rac.hidden = signal
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.view.hidden))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.view.isHidden))
 
-    observer.sendNext(false)
-    eventually(XCTAssertFalse(self.view.hidden))
+    observer.send(value: false)
+    eventually(XCTAssertFalse(self.view.isHidden))
 
-    observer.sendNext(true)
-    eventually(XCTAssertTrue(self.view.hidden))
+    observer.send(value: true)
+    eventually(XCTAssertTrue(self.view.isHidden))
   }
 
-  private final class MockView: UIView {
+  fileprivate final class MockView: UIView {
     var callback: () -> Void = {}
 
     override var alpha: CGFloat {
@@ -81,15 +81,15 @@ final class UIViewTests: XCTestCase {
     let (signal, observer) = Signal<CGFloat, NoError>.pipe()
     view.rac.alpha = signal
 
-    let expectation = expectationWithDescription("isMainThread")
+    let expectation = self.expectation(description: "isMainThread")
     view.callback = {
-      XCTAssertTrue(NSThread.isMainThread())
+      XCTAssertTrue(Thread.isMainThread)
       expectation.fulfill()
     }
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0)) {
-      observer.sendNext(0.5)
+    DispatchQueue.global(qos: .background).async {
+      observer.send(value: 0.5)
     }
-    waitForExpectationsWithTimeout(0.1, handler: nil)
+    waitForExpectations(timeout: 0.1, handler: nil)
     XCTAssertEqual(0.5, view.alpha)
   }
 }

--- a/ReactiveExtensionsTests/lib/SomeError.swift
+++ b/ReactiveExtensionsTests/lib/SomeError.swift
@@ -1,4 +1,4 @@
-internal struct SomeError: ErrorType {
+internal struct SomeError: Error {
 }
 
 extension SomeError: Equatable {}

--- a/ReactiveExtensionsTests/lib/Tuple.swift
+++ b/ReactiveExtensionsTests/lib/Tuple.swift
@@ -1,5 +1,5 @@
 public func == <A: Equatable, B: Equatable> (lhs: [(A, B)], rhs: [(A, B)]) -> Bool {
-  for (idx, _) in lhs.enumerate() {
+  for (idx, _) in lhs.enumerated() {
     if lhs[idx] != rhs[idx] {
       return false
     }

--- a/ReactiveExtensionsTests/operators/AllValuesTests.swift
+++ b/ReactiveExtensionsTests/operators/AllValuesTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -7,7 +7,7 @@ import Result
 final class AllValuesTests: XCTestCase {
 
   func testAllValues() {
-    let producer = SignalProducer<Int, NoError>(values: [1, 2, 3, 4])
+    let producer = SignalProducer<Int, NoError>([1, 2, 3, 4])
     XCTAssertEqual([1, 2, 3, 4], producer.allValues())
   }
 }

--- a/ReactiveExtensionsTests/operators/CombinePreviousTests.swift
+++ b/ReactiveExtensionsTests/operators/CombinePreviousTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -12,16 +12,16 @@ final class CombinePreviousTests: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     combinePrevious.map { [$0, $1] }.observe(test.observer)
 
-    observer.sendNext(1)
+    observer.send(value: 1)
     XCTAssertFalse(test.didEmitValue)
 
-    observer.sendNext(2)
+    observer.send(value: 2)
     test.assertValues([[1, 2]])
 
-    observer.sendNext(3)
+    observer.send(value: 3)
     test.assertValues([[1, 2], [2, 3]])
 
-    observer.sendNext(4)
+    observer.send(value: 4)
     test.assertValues([[1, 2], [2, 3], [3, 4]])
   }
 }

--- a/ReactiveExtensionsTests/operators/ConcatTests.swift
+++ b/ReactiveExtensionsTests/operators/ConcatTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -14,11 +14,11 @@ final class ConcatTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     concat.observe(test.observer)
 
-    o1.sendNext(1)
-    o1.sendNext(2)
+    o1.send(value: 1)
+    o1.send(value: 2)
     o1.sendCompleted()
-    o2.sendNext(3)
-    o2.sendNext(4)
+    o2.send(value: 3)
+    o2.send(value: 4)
     o2.sendCompleted()
 
     test.assertValues([1, 2, 3, 4])
@@ -27,19 +27,19 @@ final class ConcatTests: XCTestCase {
   func testProducer_Concat() {
     let (s1, o1) = Signal<Int, NoError>.pipe()
     let (s2, o2) = Signal<Int, NoError>.pipe()
-    let p1 = SignalProducer(signal: s1)
-    let p2 = SignalProducer(signal: s2)
+    let p1 = SignalProducer(s1)
+    let p2 = SignalProducer(s2)
 
     let concat = SignalProducer.concat(p1, p2)
 
     let test = TestObserver<Int, NoError>()
     concat.start(test.observer)
 
-    o1.sendNext(1)
-    o1.sendNext(2)
+    o1.send(value: 1)
+    o1.send(value: 2)
     o1.sendCompleted()
-    o2.sendNext(3)
-    o2.sendNext(4)
+    o2.send(value: 3)
+    o2.send(value: 4)
     o2.sendCompleted()
 
     test.assertValues([1, 2, 3, 4])

--- a/ReactiveExtensionsTests/operators/DebounceTests.swift
+++ b/ReactiveExtensionsTests/operators/DebounceTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -13,25 +13,25 @@ final class DebounceTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     debounced.observe(test.observer)
 
-    observer.sendNext(1)
+    observer.send(value: 1)
     test.assertDidNotEmitValue()
 
-    observer.sendNext(2)
+    observer.send(value: 2)
     test.assertDidNotEmitValue()
 
-    scheduler.advanceByInterval(0.3)
+    scheduler.advance(by: .milliseconds(300))
     test.assertDidNotEmitValue()
 
-    observer.sendNext(3)
+    observer.send(value: 3)
     test.assertDidNotEmitValue()
 
-    scheduler.advanceByInterval(0.8)
+    scheduler.advance(by: .milliseconds(800))
     test.assertValues([3])
 
-    observer.sendNext(4)
+    observer.send(value: 4)
     test.assertValues([3])
 
-    scheduler.advanceByInterval(0.6)
+    scheduler.advance(by: .milliseconds(600))
     test.assertValues([3, 4])
   }
 }

--- a/ReactiveExtensionsTests/operators/DebounceTests.swift
+++ b/ReactiveExtensionsTests/operators/DebounceTests.swift
@@ -9,7 +9,7 @@ final class DebounceTests: XCTestCase {
   func testDebounce() {
     let scheduler = TestScheduler()
     let (signal, observer) = Signal<Int, NoError>.pipe()
-    let debounced = signal.ksr_debounce(0.5, onScheduler: scheduler)
+    let debounced = signal.ksr_debounce(.milliseconds(500), on: scheduler)
     let test = TestObserver<Int, NoError>()
     debounced.observe(test.observer)
 

--- a/ReactiveExtensionsTests/operators/DemoteErrorsTests.swift
+++ b/ReactiveExtensionsTests/operators/DemoteErrorsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -13,10 +13,10 @@ final class DemoteErrorTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     testSignal.observe(test.observer)
 
-    observer.sendNext(1)
-    observer.sendNext(2)
-    observer.sendNext(3)
-    observer.sendFailed(SomeError())
+    observer.send(value: 1)
+    observer.send(value: 2)
+    observer.send(value: 3)
+    observer.send(error: SomeError())
 
     test.assertValues([1, 2, 3])
     test.assertDidNotFail()
@@ -30,10 +30,10 @@ final class DemoteErrorTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     testSignal.observe(test.observer)
 
-    observer.sendNext(1)
-    observer.sendNext(2)
-    observer.sendNext(3)
-    observer.sendFailed(SomeError())
+    observer.send(value: 1)
+    observer.send(value: 2)
+    observer.send(value: 3)
+    observer.send(error: SomeError())
 
     test.assertValues([1, 2, 3, 99])
     test.assertDidNotFail()
@@ -42,16 +42,16 @@ final class DemoteErrorTests: XCTestCase {
 
   func testDemoteErrors_Producer_WithDefaultArguments() {
     let (signal, observer) = Signal<Int, SomeError>.pipe()
-    let producer = SignalProducer(signal: signal)
+    let producer = SignalProducer(signal)
     let testSignal = producer.demoteErrors()
 
     let test = TestObserver<Int, NoError>()
     testSignal.start(test.observer)
 
-    observer.sendNext(1)
-    observer.sendNext(2)
-    observer.sendNext(3)
-    observer.sendFailed(SomeError())
+    observer.send(value: 1)
+    observer.send(value: 2)
+    observer.send(value: 3)
+    observer.send(error: SomeError())
 
     test.assertValues([1, 2, 3])
     test.assertDidNotFail()
@@ -60,16 +60,16 @@ final class DemoteErrorTests: XCTestCase {
 
   func testDemoteErrors_Producer_WithReplacementValue() {
     let (signal, observer) = Signal<Int, SomeError>.pipe()
-    let producer = SignalProducer(signal: signal)
+    let producer = SignalProducer(signal)
     let testSignal = producer.demoteErrors(replaceErrorWith: 99)
 
     let test = TestObserver<Int, NoError>()
     testSignal.start(test.observer)
 
-    observer.sendNext(1)
-    observer.sendNext(2)
-    observer.sendNext(3)
-    observer.sendFailed(SomeError())
+    observer.send(value: 1)
+    observer.send(value: 2)
+    observer.send(value: 3)
+    observer.send(error: SomeError())
 
     test.assertValues([1, 2, 3, 99])
     test.assertDidNotFail()

--- a/ReactiveExtensionsTests/operators/EnumeratedTests.swift
+++ b/ReactiveExtensionsTests/operators/EnumeratedTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -16,17 +16,17 @@ final class EnumeratedTests: XCTestCase {
     testIdx.assertValues([])
     testValue.assertValues([])
 
-    observer.sendNext("hello")
+    observer.send(value: "hello")
 
     testIdx.assertValues([0])
     testValue.assertValues(["hello"])
 
-    observer.sendNext("world")
+    observer.send(value: "world")
 
     testIdx.assertValues([0, 1])
     testValue.assertValues(["hello", "world"])
 
-    observer.sendNext("goodbye")
+    observer.send(value: "goodbye")
 
     testIdx.assertValues([0, 1, 2])
     testValue.assertValues(["hello", "world", "goodbye"])

--- a/ReactiveExtensionsTests/operators/ErrorsTests.swift
+++ b/ReactiveExtensionsTests/operators/ErrorsTests.swift
@@ -1,10 +1,10 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 
-private func failOnEvens(idx: Int) -> SignalProducer<Int, SomeError> {
+private func failOnEvens(_ idx: Int) -> SignalProducer<Int, SomeError> {
   return idx % 2 == 0 ? SignalProducer(error: SomeError()) : SignalProducer(value: idx)
 }
 
@@ -18,11 +18,11 @@ final class ErrorsTests: XCTestCase {
       .errors()
       .observe(test.observer)
 
-    observer.sendNext(0)
-    observer.sendNext(1)
-    observer.sendNext(2)
-    observer.sendNext(3)
-    observer.sendNext(4)
+    observer.send(value: 0)
+    observer.send(value: 1)
+    observer.send(value: 2)
+    observer.send(value: 3)
+    observer.send(value: 4)
     observer.sendCompleted()
 
     test.assertValueCount(3)
@@ -30,18 +30,18 @@ final class ErrorsTests: XCTestCase {
 
   func testProducerValues() {
     let (signal, observer) = Signal<Int, NoError>.pipe()
-    let producer = SignalProducer(signal: signal)
+    let producer = SignalProducer(signal)
     let test = TestObserver<SomeError, NoError>()
     producer
       .flatMap { idx in failOnEvens(idx).materialize() }
       .errors()
       .start(test.observer)
 
-    observer.sendNext(0)
-    observer.sendNext(1)
-    observer.sendNext(2)
-    observer.sendNext(3)
-    observer.sendNext(4)
+    observer.send(value: 0)
+    observer.send(value: 1)
+    observer.send(value: 2)
+    observer.send(value: 3)
+    observer.send(value: 4)
     observer.sendCompleted()
 
     test.assertValueCount(3)

--- a/ReactiveExtensionsTests/operators/MapConstTests.swift
+++ b/ReactiveExtensionsTests/operators/MapConstTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -12,21 +12,21 @@ final class MapConstTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     const.observe(test.observer)
 
-    observer.sendNext(1)
+    observer.send(value: 1)
     test.assertValues([5])
 
-    observer.sendNext(2)
+    observer.send(value: 2)
     test.assertValues([5, 5])
 
-    observer.sendNext(3)
+    observer.send(value: 3)
     test.assertValues([5, 5, 5])
 
-    observer.sendNext(4)
+    observer.send(value: 4)
     test.assertValues([5, 5, 5, 5])
   }
 
   func testSignalProducerMapConst() {
-    let producer = SignalProducer<Int, NoError>(values: [1, 2, 3, 4])
+    let producer = SignalProducer<Int, NoError>([1, 2, 3, 4])
       .mapConst(5)
     let test = TestObserver<Int, NoError>()
     producer.start(test.observer)

--- a/ReactiveExtensionsTests/operators/ScanTests.swift
+++ b/ReactiveExtensionsTests/operators/ScanTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -12,10 +12,10 @@ final class ScanTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     scan.observe(test.observer)
 
-    observer.sendNext(1)
-    observer.sendNext(2)
-    observer.sendNext(3)
-    observer.sendNext(4)
+    observer.send(value: 1)
+    observer.send(value: 2)
+    observer.send(value: 3)
+    observer.send(value: 4)
 
     test.assertValues([1, 3, 6, 10])
 

--- a/ReactiveExtensionsTests/operators/SlidingWindowTest.swift
+++ b/ReactiveExtensionsTests/operators/SlidingWindowTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -12,19 +12,19 @@ final class SlidingWindowTest: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     window.observe(test.observer)
 
-    observer.sendNext(1)
+    observer.send(value: 1)
     test.assertValues([])
 
-    observer.sendNext(2)
+    observer.send(value: 2)
     test.assertValues([[1, 2]])
 
-    observer.sendNext(3)
+    observer.send(value: 3)
     test.assertValues([[1, 2], [1, 2, 3]])
 
-    observer.sendNext(4)
+    observer.send(value: 4)
     test.assertValues([[1, 2], [1, 2, 3], [2, 3, 4]])
 
-    observer.sendNext(5)
+    observer.send(value: 5)
     test.assertValues([[1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5]])
   }
 
@@ -34,16 +34,16 @@ final class SlidingWindowTest: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     window.observe(test.observer)
 
-    observer.sendNext(1)
+    observer.send(value: 1)
     test.assertValues([[1]])
 
-    observer.sendNext(2)
+    observer.send(value: 2)
     test.assertValues([[1], [1, 2]])
 
-    observer.sendNext(3)
+    observer.send(value: 3)
     test.assertValues([[1], [1, 2], [2, 3]])
 
-    observer.sendNext(4)
+    observer.send(value: 4)
     test.assertValues([[1], [1, 2], [2, 3], [3, 4]])
   }
 
@@ -53,42 +53,42 @@ final class SlidingWindowTest: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     window.observe(test.observer)
 
-    observer.sendNext(1)
+    observer.send(value: 1)
     test.assertValues([])
 
-    observer.sendNext(2)
+    observer.send(value: 2)
     test.assertValues([])
 
-    observer.sendNext(3)
+    observer.send(value: 3)
     test.assertValues([[1, 2, 3]])
 
-    observer.sendNext(4)
+    observer.send(value: 4)
     test.assertValues([[1, 2, 3], [2, 3, 4]])
 
-    observer.sendNext(5)
+    observer.send(value: 5)
     test.assertValues([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
   }
 
   func testProducer_SlidingWindowWithMaxLessThanMin() {
     let (signal, observer) = Signal<Int, NoError>.pipe()
-    let producer = SignalProducer(signal: signal)
+    let producer = SignalProducer(signal)
     let window = producer.slidingWindow(max: 3, min: 2)
     let test = TestObserver<[Int], NoError>()
     window.start(test.observer)
 
-    observer.sendNext(1)
+    observer.send(value: 1)
     test.assertDidNotEmitValue()
 
-    observer.sendNext(2)
+    observer.send(value: 2)
     test.assertValues([[1, 2]])
 
-    observer.sendNext(3)
+    observer.send(value: 3)
     test.assertValues([[1, 2], [1, 2, 3]])
 
-    observer.sendNext(4)
+    observer.send(value: 4)
     test.assertValues([[1, 2], [1, 2, 3], [2, 3, 4]])
 
-    observer.sendNext(5)
+    observer.send(value: 5)
     test.assertValues([[1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5]])
 
     observer.sendCompleted()

--- a/ReactiveExtensionsTests/operators/SortTests.swift
+++ b/ReactiveExtensionsTests/operators/SortTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -12,9 +12,9 @@ final class SortTests: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     sort.observe(test.observer)
 
-    observer.sendNext([2, 1, 3])
-    observer.sendNext([3, 2, 1])
-    observer.sendNext([1, 2, 3])
+    observer.send(value: [2, 1, 3])
+    observer.send(value: [3, 2, 1])
+    observer.send(value: [1, 2, 3])
 
     test.assertValues([[1, 2, 3], [1, 2, 3], [1, 2, 3]])
   }
@@ -25,15 +25,15 @@ final class SortTests: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     sort.observe(test.observer)
 
-    observer.sendNext([2, 1, 3])
-    observer.sendNext([3, 2, 1])
-    observer.sendNext([1, 2, 3])
+    observer.send(value: [2, 1, 3])
+    observer.send(value: [3, 2, 1])
+    observer.send(value: [1, 2, 3])
 
     test.assertValues([[3, 2, 1], [3, 2, 1], [3, 2, 1]])
   }
 
   func testSignalProducerSort() {
-    let producer = SignalProducer<[Int], NoError>(values: [[2, 1, 3], [3, 2, 1], [1, 2, 3]])
+    let producer = SignalProducer<[Int], NoError>([[2, 1, 3], [3, 2, 1], [1, 2, 3]])
     let sort = producer.sort()
     let test = TestObserver<[Int], NoError>()
     sort.start(test.observer)
@@ -42,7 +42,7 @@ final class SortTests: XCTestCase {
   }
 
   func testSignalProducerSortWithComparator() {
-    let producer = SignalProducer<[Int], NoError>(values: [[2, 1, 3], [3, 2, 1], [1, 2, 3]])
+    let producer = SignalProducer<[Int], NoError>([[2, 1, 3], [3, 2, 1], [1, 2, 3]])
     let sort = producer.sort(>)
     let test = TestObserver<[Int], NoError>()
     sort.start(test.observer)

--- a/ReactiveExtensionsTests/operators/TakeUntilTests.swift
+++ b/ReactiveExtensionsTests/operators/TakeUntilTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -12,10 +12,10 @@ final class TakeUntilTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     takeUntil.observe(test.observer)
 
-    observer.sendNext(1)
-    observer.sendNext(3)
-    observer.sendNext(5)
-    observer.sendNext(2)
+    observer.send(value: 1)
+    observer.send(value: 3)
+    observer.send(value: 5)
+    observer.send(value: 2)
 
     test.assertValues([1, 3, 5, 2])
     test.assertDidComplete()

--- a/ReactiveExtensionsTests/operators/TakeWhenTests.swift
+++ b/ReactiveExtensionsTests/operators/TakeWhenTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -13,16 +13,16 @@ final class TakeWhenTests: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     takePairWhen.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
+    sourceObserver.send(value: 1)
     test.assertValues([])
 
-    sourceObserver.sendNext(2)
+    sourceObserver.send(value: 2)
     test.assertValues([])
 
-    sampleObserver.sendNext(3)
+    sampleObserver.send(value: 3)
     test.assertValues([[2, 3]])
 
-    sampleObserver.sendNext(4)
+    sampleObserver.send(value: 4)
     test.assertValues([[2, 3], [2, 4]])
 
     sampleObserver.sendCompleted()
@@ -39,8 +39,8 @@ final class TakeWhenTests: XCTestCase {
     let test = TestObserver<[Int], SomeError>()
     takePairWhen.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[1, 3]])
 
     sourceObserver.sendCompleted()
@@ -54,11 +54,11 @@ final class TakeWhenTests: XCTestCase {
     let test = TestObserver<[Int], SomeError>()
     takePairWhen.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[1, 3]])
 
-    sourceObserver.sendFailed(SomeError())
+    sourceObserver.send(error: SomeError())
     test.assertDidFail()
   }
 
@@ -69,8 +69,8 @@ final class TakeWhenTests: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     takePairWhen.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[1, 3]])
 
     sourceObserver.sendInterrupted()
@@ -84,11 +84,11 @@ final class TakeWhenTests: XCTestCase {
     let test = TestObserver<[Int], SomeError>()
     takePairWhen.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[1, 3]])
 
-    sampleObserver.sendFailed(SomeError())
+    sampleObserver.send(error: SomeError())
     test.assertDidNotFail()
   }
 
@@ -99,8 +99,8 @@ final class TakeWhenTests: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     takePairWhen.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[1, 3]])
 
     sampleObserver.sendInterrupted()
@@ -114,17 +114,17 @@ final class TakeWhenTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     takeWhen.observe(test.observer)
 
-    sourceObserver.sendNext(1)
+    sourceObserver.send(value: 1)
     test.assertValues([])
 
-    sourceObserver.sendNext(2)
+    sourceObserver.send(value: 2)
     test.assertValues([])
 
-    sampleObserver.sendNext(3)
+    sampleObserver.send(value: 3)
     test.assertValues([2])
 
-    sourceObserver.sendNext(4)
-    sampleObserver.sendNext(5)
+    sourceObserver.send(value: 4)
+    sampleObserver.send(value: 5)
     test.assertValues([2, 4])
 
     sampleObserver.sendCompleted()

--- a/ReactiveExtensionsTests/operators/UncollectTests.swift
+++ b/ReactiveExtensionsTests/operators/UncollectTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -12,7 +12,7 @@ class UncollectTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     uncollected.observe(test.observer)
 
-    observer.sendNext([1, 2, 3])
+    observer.send(value: [1, 2, 3])
 
     test.assertValues([1, 2, 3])
     test.assertDidNotComplete()
@@ -27,8 +27,8 @@ class UncollectTests: XCTestCase {
     let test = TestObserver<Int, SomeError>()
     uncollected.observe(test.observer)
 
-    observer.sendNext([1, 2, 3])
-    observer.sendFailed(SomeError())
+    observer.send(value: [1, 2, 3])
+    observer.send(error: SomeError())
 
     test.assertValues([1, 2, 3])
     test.assertDidFail()
@@ -40,7 +40,7 @@ class UncollectTests: XCTestCase {
     let test = TestObserver<Int, NoError>()
     uncollected.observe(test.observer)
 
-    observer.sendNext([1, 2, 3])
+    observer.send(value: [1, 2, 3])
     observer.sendInterrupted()
 
     test.assertValues([1, 2, 3])

--- a/ReactiveExtensionsTests/operators/ValuesTests.swift
+++ b/ReactiveExtensionsTests/operators/ValuesTests.swift
@@ -1,10 +1,10 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 
-private func failOnEvens(idx: Int) -> SignalProducer<Int, SomeError> {
+private func failOnEvens(_ idx: Int) -> SignalProducer<Int, SomeError> {
   return idx % 2 == 0 ? SignalProducer(error: SomeError()) : SignalProducer(value: idx)
 }
 
@@ -18,11 +18,11 @@ final class ValuesTests: XCTestCase {
       .values()
       .observe(test.observer)
 
-    observer.sendNext(0)
-    observer.sendNext(1)
-    observer.sendNext(2)
-    observer.sendNext(3)
-    observer.sendNext(4)
+    observer.send(value: 0)
+    observer.send(value: 1)
+    observer.send(value: 2)
+    observer.send(value: 3)
+    observer.send(value: 4)
     observer.sendCompleted()
 
     test.assertValues([1, 3])
@@ -30,18 +30,18 @@ final class ValuesTests: XCTestCase {
 
   func testProducerValues() {
     let (signal, observer) = Signal<Int, NoError>.pipe()
-    let producer = SignalProducer(signal: signal)
+    let producer = SignalProducer(signal)
     let test = TestObserver<Int, NoError>()
     producer
       .flatMap { idx in failOnEvens(idx).materialize() }
       .values()
       .start(test.observer)
 
-    observer.sendNext(0)
-    observer.sendNext(1)
-    observer.sendNext(2)
-    observer.sendNext(3)
-    observer.sendNext(4)
+    observer.send(value: 0)
+    observer.send(value: 1)
+    observer.send(value: 2)
+    observer.send(value: 3)
+    observer.send(value: 4)
     observer.sendCompleted()
 
     test.assertValues([1, 3])

--- a/ReactiveExtensionsTests/operators/WithLatestFromTests.swift
+++ b/ReactiveExtensionsTests/operators/WithLatestFromTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import ReactiveCocoa
+import ReactiveSwift
 import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
@@ -13,16 +13,16 @@ final class WithLatestFromTests: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
+    sourceObserver.send(value: 1)
     test.assertValues([])
 
-    sourceObserver.sendNext(2)
+    sourceObserver.send(value: 2)
     test.assertValues([])
 
-    sampleObserver.sendNext(3)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 2]])
 
-    sampleObserver.sendNext(4)
+    sampleObserver.send(value: 4)
     test.assertValues([[3, 2], [4, 2]])
 
     sampleObserver.sendCompleted()
@@ -39,8 +39,8 @@ final class WithLatestFromTests: XCTestCase {
     let test = TestObserver<[Int], SomeError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
     sourceObserver.sendCompleted()
@@ -54,11 +54,11 @@ final class WithLatestFromTests: XCTestCase {
     let test = TestObserver<[Int], SomeError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
-    sourceObserver.sendFailed(SomeError())
+    sourceObserver.send(error: SomeError())
     XCTAssert(test.didFail)
   }
 
@@ -69,8 +69,8 @@ final class WithLatestFromTests: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
     sourceObserver.sendInterrupted()
@@ -84,11 +84,11 @@ final class WithLatestFromTests: XCTestCase {
     let test = TestObserver<[Int], SomeError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
-    sampleObserver.sendFailed(SomeError())
+    sampleObserver.send(error: SomeError())
     test.assertDidNotFail()
   }
 
@@ -99,8 +99,8 @@ final class WithLatestFromTests: XCTestCase {
     let test = TestObserver<[Int], NoError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
     sampleObserver.sendInterrupted()
@@ -110,21 +110,21 @@ final class WithLatestFromTests: XCTestCase {
   func testWithLatestFromProducer() {
     let (source, sourceObserver) = Signal<Int, NoError>.pipe()
     let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
-    let sourceProducer = SignalProducer(signal: source)
+    let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
     let test = TestObserver<[Int], NoError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
+    sourceObserver.send(value: 1)
     test.assertValues([])
 
-    sourceObserver.sendNext(2)
+    sourceObserver.send(value: 2)
     test.assertValues([])
 
-    sampleObserver.sendNext(3)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 2]])
 
-    sampleObserver.sendNext(4)
+    sampleObserver.send(value: 4)
     test.assertValues([[3, 2], [4, 2]])
 
     sampleObserver.sendCompleted()
@@ -139,13 +139,13 @@ final class WithLatestFromTests: XCTestCase {
   func testWithLatestFromProducer_SourceCompleting() {
     let (source, sourceObserver) = Signal<Int, NoError>.pipe()
     let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
-    let sourceProducer = SignalProducer(signal: source)
+    let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
     let test = TestObserver<[Int], NoError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
     sourceObserver.sendCompleted()
@@ -156,29 +156,29 @@ final class WithLatestFromTests: XCTestCase {
   func testWithLatestFromProducer_SourceErroring() {
     let (source, sourceObserver) = Signal<Int, SomeError>.pipe()
     let (sample, sampleObserver) = Signal<Int, SomeError>.pipe()
-    let sourceProducer = SignalProducer(signal: source)
+    let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
     let test = TestObserver<[Int], SomeError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
-    sourceObserver.sendFailed(SomeError())
+    sourceObserver.send(error: SomeError())
     XCTAssert(test.didFail)
   }
 
   func testWithLatestFromProducer_SourceInterrupted() {
     let (source, sourceObserver) = Signal<Int, NoError>.pipe()
     let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
-    let sourceProducer = SignalProducer(signal: source)
+    let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
     let test = TestObserver<[Int], NoError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
     sourceObserver.sendInterrupted()
@@ -188,16 +188,16 @@ final class WithLatestFromTests: XCTestCase {
   func testWithLatestFromProducer_SampleErroring() {
     let (source, sourceObserver) = Signal<Int, SomeError>.pipe()
     let (sample, sampleObserver) = Signal<Int, SomeError>.pipe()
-    let sourceProducer = SignalProducer(signal: source)
+    let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
     let test = TestObserver<[Int], SomeError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
-    sampleObserver.sendFailed(SomeError())
+    sampleObserver.send(error: SomeError())
 
     test.assertDidNotFail()
   }
@@ -205,13 +205,13 @@ final class WithLatestFromTests: XCTestCase {
   func testWithLatestFromProducer_SampleInterrupted() {
     let (source, sourceObserver) = Signal<Int, NoError>.pipe()
     let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
-    let sourceProducer = SignalProducer(signal: source)
+    let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
     let test = TestObserver<[Int], NoError>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
-    sourceObserver.sendNext(1)
-    sampleObserver.sendNext(3)
+    sourceObserver.send(value: 1)
+    sampleObserver.send(value: 3)
     test.assertValues([[3, 1]])
 
     sampleObserver.sendInterrupted()

--- a/bin/test
+++ b/bin/test
@@ -8,13 +8,13 @@ if [ $# -eq 0 ]; then
 fi
 
 if [ "$1" == "iOS" ]; then
-  DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.3'
+  DESTINATION='platform=iOS Simulator,name=iPhone 6,OS='
 else
-  DESTINATION='platform=tvOS Simulator,name=Apple TV 1080p,OS=9.2'
+  DESTINATION='platform=tvOS Simulator,name=Apple TV 1080p,OS='
 fi
 
 xcodebuild \
-  -destination "$DESTINATION" \
+  -destination "$DESTINATION$2" \
   -scheme ReactiveExtensions-$1 \
   clean test \
   | tee $CIRCLE_ARTIFACTS/xcode_raw.log \

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,15 @@
 machine:
   xcode:
-    version: 7.3
+    version: 8.2
 dependencies:
   pre:
     - brew update || brew update
     - brew install swiftlint
+    - system_profiler SPSoftwareDataType
+    - security list-keychains
+    - security find-identity -p codesigning
+    - instruments -s devices
+    - xcodebuild -showsdks
   override:
     - git submodule sync --recursive
     - git submodule update --init --recursive
@@ -16,7 +21,9 @@ test:
     - set -o pipefail &&
       swiftlint lint --strict --reporter json |
       tee $CIRCLE_ARTIFACTS/swiftlint-report.json
-    - bin/test iOS
+    - bin/test iOS 9.3
+    - bin/test iOS 10.1
+    - bin/test tvOS 10.1
 experimental:
   notify:
     branches:


### PR DESCRIPTION
This updates ReactiveExtensions to be Swift 3 compatible. This does not change our APIs to be more "Swift 3 like". We should do that in a separate PR so that we can concentrate only on Swift 3 and not a bunch of other API-breaking changes.

We are now using the [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift) framework, which is the pure swift version of the core of ReactiveCocoa. It's still at [RC 1](https://github.com/ReactiveCocoa/ReactiveSwift/releases/tag/1.0.0-rc.1) so we should track the changes closely, but tests pass, so... ¯\\_(ツ)_/¯ 

Also, this was way easier than I expected. Took less than 30 minutes.