### PR TITLE
Remove deprecation and swiftlint

### DIFF
--- a/ReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ReactiveExtensions.xcodeproj/project.pbxproj
@@ -1531,8 +1531,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1551,8 +1549,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1701,7 +1697,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1719,7 +1715,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/ReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ReactiveExtensions.xcodeproj/project.pbxproj
@@ -1386,6 +1386,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				CODE_SIGN_IDENTITY = "";
 				INFOPLIST_FILE = ReactiveExtensionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kickstarter.ReactiveExtensionsTests;
@@ -1399,6 +1400,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				CODE_SIGN_IDENTITY = "";
 				INFOPLIST_FILE = ReactiveExtensionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kickstarter.ReactiveExtensionsTests;
@@ -1411,7 +1413,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1441,7 +1442,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1471,8 +1471,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1502,8 +1501,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/ReactiveExtensions/LazyAssociatedProperty.swift
+++ b/ReactiveExtensions/LazyAssociatedProperty.swift
@@ -18,7 +18,7 @@ import Foundation
  Otherwise the `factory` closure is invoked and that value is returned.
  */
 internal func lazyAssociatedProperty <T: AnyObject> (_ host: AnyObject, key: UnsafeRawPointer,
-                                      factory: (Void) -> T) -> T {
+                                                     factory: (Void) -> T) -> T {
 
   if let value = objc_getAssociatedObject(host, key) as? T {
     return value

--- a/ReactiveExtensions/LazyMutableProperty.swift
+++ b/ReactiveExtensions/LazyMutableProperty.swift
@@ -12,7 +12,7 @@ import ReactiveSwift
  - returns:
  */
 public func lazyMutableProperty<T>(_ host: AnyObject, key: UnsafeRawPointer, setter: @escaping (T) -> Void,
-                                  getter: @escaping () -> T) -> MutableProperty<T> {
+                                   getter: @escaping () -> T) -> MutableProperty<T> {
   return lazyAssociatedProperty(host, key: key) {
     let property = MutableProperty<T>(getter())
     property.producer.skip(first: 1).startWithValues { value in

--- a/ReactiveExtensionsTests/TestHelpers/Event-Extensions.swift
+++ b/ReactiveExtensionsTests/TestHelpers/Event-Extensions.swift
@@ -3,7 +3,7 @@ import ReactiveSwift
 internal extension Event {
 
   @available(*, deprecated, message: "Rename this to `isValue`.")
-  internal var isNext: Bool {
+  internal var isValue: Bool {
     if case .value = self {
       return true
     }

--- a/ReactiveExtensionsTests/TestHelpers/Event-Extensions.swift
+++ b/ReactiveExtensionsTests/TestHelpers/Event-Extensions.swift
@@ -1,8 +1,6 @@
 import ReactiveSwift
 
 internal extension Event {
-
-  @available(*, deprecated, message: "Rename this to `isValue`.")
   internal var isValue: Bool {
     if case .value = self {
       return true

--- a/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
+++ b/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
@@ -31,7 +31,7 @@ internal final class TestObserver <Value, Error: Swift.Error> {
 
   /// Get all of the next values emitted by the signal.
   internal var values: [Value] {
-    return self.events.filter { $0.isNext }.map { $0.value! }
+    return self.events.filter { $0.isValue }.map { $0.value! }
   }
 
   /// Get the last value emitted by the signal.

--- a/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
+++ b/ReactiveExtensionsTests/TestHelpers/TestObserver.swift
@@ -25,7 +25,7 @@ internal final class TestObserver <Value, Error: Swift.Error> {
     self.observer = Observer<Value, Error>(action)
   }
 
-  private func action(_ event: Event<Value, Error>) -> Void {
+  private func action(_ event: Event<Value, Error>) {
     self.events.append(event)
   }
 
@@ -65,42 +65,42 @@ internal final class TestObserver <Value, Error: Swift.Error> {
   }
 
   internal func assertDidComplete(_ message: String = "Should have completed.",
-    file: StaticString = #file, line: UInt = #line) {
+                                  file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didComplete, message, file: file, line: line)
   }
 
   internal func assertDidFail(_ message: String = "Should have failed.",
-    file: StaticString = #file, line: UInt = #line) {
+                              file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didFail, message, file: file, line: line)
   }
 
   internal func assertDidNotFail(_ message: String = "Should not have failed.",
-    file: StaticString = #file, line: UInt = #line) {
+                                 file: StaticString = #file, line: UInt = #line) {
       XCTAssertFalse(self.didFail, message, file: file, line: line)
   }
 
   internal func assertDidInterrupt(_ message: String = "Should have failed.",
-    file: StaticString = #file, line: UInt = #line) {
+                                   file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didInterrupt, message, file: file, line: line)
   }
 
   internal func assertDidNotInterrupt(_ message: String = "Should not have failed.",
-    file: StaticString = #file, line: UInt = #line) {
+                                      file: StaticString = #file, line: UInt = #line) {
       XCTAssertFalse(self.didInterrupt, message, file: file, line: line)
   }
 
   internal func assertDidNotComplete(_ message: String = "Should not have completed",
-    file: StaticString = #file, line: UInt = #line) {
+                                     file: StaticString = #file, line: UInt = #line) {
       XCTAssertFalse(self.didComplete, message, file: file, line: line)
   }
 
   internal func assertDidEmitValue(_ message: String = "Should have emitted at least one value.",
-    file: StaticString = #file, line: UInt = #line) {
+                                   file: StaticString = #file, line: UInt = #line) {
       XCTAssert(self.values.count > 0, message, file: file, line: line)
   }
 
   internal func assertDidNotEmitValue(_ message: String = "Should not have emitted any values.",
-    file: StaticString = #file, line: UInt = #line) {
+                                      file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(0, self.values.count, message, file: file, line: line)
   }
 
@@ -117,7 +117,7 @@ internal final class TestObserver <Value, Error: Swift.Error> {
   }
 
   internal func assertValueCount(_ count: Int, _ message: String? = nil,
-    file: StaticString = #file, line: UInt = #line) {
+                                 file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(count, self.values.count, message ?? "Should have emitted \(count) values",
         file: file, line: line)
   }
@@ -132,13 +132,13 @@ extension TestObserver where Value: Equatable {
   }
 
   internal func assertLastValue(_ value: Value, _ message: String? = nil,
-                            file: StaticString = #file, line: UInt = #line) {
+                                file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(value, self.lastValue, message ?? "Last emitted value is equal to \(value).",
                    file: file, line: line)
   }
 
   internal func assertValues(_ values: [Value], _ message: String = "",
-    file: StaticString = #file, line: UInt = #line) {
+                             file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(values, self.values, message, file: file, line: line)
   }
 }
@@ -177,14 +177,14 @@ extension TestObserver where Value: Sequence, Value.Iterator.Element: Equatable 
   }
 
   internal func assertLastValue(_ value: Value, _ message: String? = nil,
-                            file: StaticString = #file, line: UInt = #line) {
+                                file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(Array(value), self.lastValue.map(Array.init) ?? [],
                    message ?? "Last emitted value is equal to \(value).",
                    file: file, line: line)
   }
 
   internal func assertValues(_ values: [[Value.Iterator.Element]], _ message: String = "",
-    file: StaticString = #file, line: UInt = #line) {
+                             file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(Array(values), Array(self.values.map(Array.init)), message, file: file, line: line)
   }
 
@@ -192,7 +192,7 @@ extension TestObserver where Value: Sequence, Value.Iterator.Element: Equatable 
 
 extension TestObserver where Error: Equatable {
   internal func assertFailed(_ expectedError: Error, message: String = "",
-    file: StaticString = #file, line: UInt = #line) {
+                             file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(expectedError, self.failedError, message, file: file, line: line)
   }
 }

--- a/ReactiveExtensionsTests/TestHelpers/XCTAssert-Extensions.swift
+++ b/ReactiveExtensionsTests/TestHelpers/XCTAssert-Extensions.swift
@@ -3,8 +3,8 @@ import ReactiveSwift
 
 // Assert equality between two doubly nested arrays of equatables.
 internal func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () -> [[T]],
-  _ expression2: @autoclosure () -> [[T]], _ message: String = "",
-                 file: StaticString = #file, line: UInt = #line) {
+                                           _ expression2: @autoclosure () -> [[T]], _ message: String = "",
+                                           file: StaticString = #file, line: UInt = #line) {
 
     let lhs = expression1()
     let rhs = expression2()

--- a/ReactiveExtensionsTests/TestHelpers/XCTestCase+Async.swift
+++ b/ReactiveExtensionsTests/TestHelpers/XCTestCase+Async.swift
@@ -2,8 +2,8 @@ import XCTest
 
 extension XCTestCase {
   internal func async(expect description: String = "async",
-                             timeout: Double = 5,
-                             block: @escaping (() -> Void) -> Void) {
+                      timeout: Double = 5,
+                      block: @escaping (() -> Void) -> Void) {
     let expectation = self.expectation(description: description)
     DispatchQueue.main.async {
       block(expectation.fulfill)


### PR DESCRIPTION
During our swift 3 upgrade #54 we made a deprecation warning. I wanna get rid of it. Trying to clean up our xcode warnings.

Also fixed a bunch of swiftlint errors.