### PR TITLE
Add string-specific extensions

### DIFF
--- a/ReactiveExtensions/operators/EnumeratedTests.swift
+++ b/ReactiveExtensions/operators/EnumeratedTests.swift
@@ -14,7 +14,7 @@ final class EnumeratedTests: XCTestCase {
     signal.enumerated().map { _, value in value }.observe(testValue.observer)
 
     testIdx.assertValues([])
-    testValue.assertValues([])
+    testValue.assertValueCount(0)
 
     observer.send(value: "hello")
 

--- a/ReactiveExtensions/test-helpers/TestObserver.swift
+++ b/ReactiveExtensions/test-helpers/TestObserver.swift
@@ -192,15 +192,13 @@ extension TestObserver where Value: Sequence, Value.Iterator.Element == Characte
                             file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
     XCTAssertEqual(Array(value), self.lastValue.map(Array.init) ?? [],
-                   message ?? "A single value of \(value) should have been emitted",
-      file: file, line: line)
+                   message ?? "A single value of \(value) should have been emitted", file: file, line: line)
   }
 
   internal func assertLastValue(_ value: Value, _ message: String? = nil,
                                 file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(Array(value), self.lastValue.map(Array.init) ?? [],
-                   message ?? "Last emitted value is equal to \(value).",
-      file: file, line: line)
+                   message ?? "Last emitted value is equal to \(value).", file: file, line: line)
   }
 
   internal func assertValues(_ values: [[Value.Iterator.Element]], _ message: String = "",
@@ -230,7 +228,6 @@ extension TestObserver where Value: Sequence, Value.Iterator.Element: Equatable 
                              file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(Array(values), Array(self.values.map(Array.init)), message, file: file, line: line)
   }
-
 }
 
 extension TestObserver where Error: Equatable {

--- a/ReactiveExtensions/test-helpers/TestObserver.swift
+++ b/ReactiveExtensions/test-helpers/TestObserver.swift
@@ -123,6 +123,26 @@ internal final class TestObserver <Value, Error: Swift.Error> {
   }
 }
 
+extension TestObserver where Value: StringProtocol {
+  internal func assertValue(_ value: Value, _ message: String? = nil,
+                            file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
+    XCTAssertEqual(value, self.lastValue, message ?? "A single value of \(value) should have been emitted",
+      file: file, line: line)
+  }
+
+  internal func assertLastValue(_ value: Value, _ message: String? = nil,
+                                file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(value, self.lastValue, message ?? "Last emitted value is equal to \(value).",
+      file: file, line: line)
+  }
+
+  internal func assertValues(_ values: [Value], _ message: String = "",
+                             file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(values, self.values, message, file: file, line: line)
+  }
+}
+
 extension TestObserver where Value: Equatable {
   internal func assertValue(_ value: Value, _ message: String? = nil,
                             file: StaticString = #file, line: UInt = #line) {
@@ -163,6 +183,29 @@ extension TestObserver where Value: ReactiveSwift.OptionalProtocol, Value.Wrappe
   internal func assertValues(_ values: [Value], _ message: String = "",
                              file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(values, self.values, message, file: file, line: line)
+  }
+}
+
+extension TestObserver where Value: Sequence, Value.Iterator.Element == Character {
+
+  internal func assertValue(_ value: Value, _ message: String? = nil,
+                            file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
+    XCTAssertEqual(Array(value), self.lastValue.map(Array.init) ?? [],
+                   message ?? "A single value of \(value) should have been emitted",
+      file: file, line: line)
+  }
+
+  internal func assertLastValue(_ value: Value, _ message: String? = nil,
+                                file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(Array(value), self.lastValue.map(Array.init) ?? [],
+                   message ?? "Last emitted value is equal to \(value).",
+      file: file, line: line)
+  }
+
+  internal func assertValues(_ values: [[Value.Iterator.Element]], _ message: String = "",
+                             file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(Array(values), Array(self.values.map(Array.init)), message, file: file, line: line)
   }
 }
 

--- a/ReactiveExtensions/test-helpers/TestObserver.swift
+++ b/ReactiveExtensions/test-helpers/TestObserver.swift
@@ -123,6 +123,7 @@ internal final class TestObserver <Value, Error: Swift.Error> {
   }
 }
 
+#if swift(>=3.2)
 extension TestObserver where Value: StringProtocol {
   internal func assertValue(_ value: Value, _ message: String? = nil,
                             file: StaticString = #file, line: UInt = #line) {
@@ -142,6 +143,7 @@ extension TestObserver where Value: StringProtocol {
     XCTAssertEqual(values, self.values, message, file: file, line: line)
   }
 }
+#endif
 
 extension TestObserver where Value: Equatable {
   internal func assertValue(_ value: Value, _ message: String? = nil,

--- a/ReactiveExtensions/test-helpers/TestObserver.swift
+++ b/ReactiveExtensions/test-helpers/TestObserver.swift
@@ -123,28 +123,6 @@ internal final class TestObserver <Value, Error: Swift.Error> {
   }
 }
 
-#if swift(>=3.2)
-extension TestObserver where Value: StringProtocol {
-  internal func assertValue(_ value: Value, _ message: String? = nil,
-                            file: StaticString = #file, line: UInt = #line) {
-    XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
-    XCTAssertEqual(value, self.lastValue, message ?? "A single value of \(value) should have been emitted",
-      file: file, line: line)
-  }
-
-  internal func assertLastValue(_ value: Value, _ message: String? = nil,
-                                file: StaticString = #file, line: UInt = #line) {
-    XCTAssertEqual(value, self.lastValue, message ?? "Last emitted value is equal to \(value).",
-      file: file, line: line)
-  }
-
-  internal func assertValues(_ values: [Value], _ message: String = "",
-                             file: StaticString = #file, line: UInt = #line) {
-    XCTAssertEqual(values, self.values, message, file: file, line: line)
-  }
-}
-#endif
-
 extension TestObserver where Value: Equatable {
   internal func assertValue(_ value: Value, _ message: String? = nil,
                             file: StaticString = #file, line: UInt = #line) {
@@ -185,27 +163,6 @@ extension TestObserver where Value: ReactiveSwift.OptionalProtocol, Value.Wrappe
   internal func assertValues(_ values: [Value], _ message: String = "",
                              file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(values, self.values, message, file: file, line: line)
-  }
-}
-
-extension TestObserver where Value: Sequence, Value.Iterator.Element == Character {
-
-  internal func assertValue(_ value: Value, _ message: String? = nil,
-                            file: StaticString = #file, line: UInt = #line) {
-    XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
-    XCTAssertEqual(Array(value), self.lastValue.map(Array.init) ?? [],
-                   message ?? "A single value of \(value) should have been emitted", file: file, line: line)
-  }
-
-  internal func assertLastValue(_ value: Value, _ message: String? = nil,
-                                file: StaticString = #file, line: UInt = #line) {
-    XCTAssertEqual(Array(value), self.lastValue.map(Array.init) ?? [],
-                   message ?? "Last emitted value is equal to \(value).", file: file, line: line)
-  }
-
-  internal func assertValues(_ values: [[Value.Iterator.Element]], _ message: String = "",
-                             file: StaticString = #file, line: UInt = #line) {
-    XCTAssertEqual(Array(values), Array(self.values.map(Array.init)), message, file: file, line: line)
   }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -15,15 +15,14 @@ dependencies:
     - git submodule update --init --recursive
 test:
   pre:
-    - xcrun instruments -w '547B1B63-3F66-4E5B-8001-F78F2F1CDEA7' || true
+    - xcrun instruments -w 'iPhone 7 (10.2)' || true
     - sleep 15
   override:
     - set -o pipefail &&
       swiftlint lint --strict --reporter json |
       tee $CIRCLE_ARTIFACTS/swiftlint-report.json
-    - bin/test iOS 9.3
     - bin/test iOS 10.2
-    - bin/test tvOS 10.0
+    - bin/test iOS 11.0
 experimental:
   notify:
     branches:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 8.3
+    version: "9.0"
 dependencies:
   pre:
     - brew update || brew update


### PR DESCRIPTION
`String` now conforms to `Sequence` in Swift 3.2 and Xcode 9:

`String` : `StringProtocol` : `BidirectionalCollection` : `Sequence`

This meant that our extensions on `TestObserver` weren't specific enough and were causing ambiguity in our `assertValue()` calls when specifying a `String` value.

By adding these extensions more specifically we can help the compiler to figure out what we mean.

Note these are just copy-pasted, perhaps we could be more DRY?