### PR TITLE
Support Carthage in main app

### DIFF
--- a/ReactiveExtensions.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ReactiveExtensions.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>

--- a/ReactiveExtensions/test-helpers/TestObserver.swift
+++ b/ReactiveExtensions/test-helpers/TestObserver.swift
@@ -65,87 +65,87 @@ public final class TestObserver <Value, Error: Swift.Error> {
   }
 
   public func assertDidComplete(_ message: String = "Should have completed.",
-                                  file: StaticString = #file, line: UInt = #line) {
-      XCTAssertTrue(self.didComplete, message, file: file, line: line)
+                                file: StaticString = #file, line: UInt = #line) {
+    XCTAssertTrue(self.didComplete, message, file: file, line: line)
   }
 
   public func assertDidFail(_ message: String = "Should have failed.",
-                              file: StaticString = #file, line: UInt = #line) {
-      XCTAssertTrue(self.didFail, message, file: file, line: line)
+                            file: StaticString = #file, line: UInt = #line) {
+    XCTAssertTrue(self.didFail, message, file: file, line: line)
   }
 
   public func assertDidNotFail(_ message: String = "Should not have failed.",
-                                 file: StaticString = #file, line: UInt = #line) {
-      XCTAssertFalse(self.didFail, message, file: file, line: line)
+                               file: StaticString = #file, line: UInt = #line) {
+    XCTAssertFalse(self.didFail, message, file: file, line: line)
   }
 
   public func assertDidInterrupt(_ message: String = "Should have failed.",
-                                   file: StaticString = #file, line: UInt = #line) {
-      XCTAssertTrue(self.didInterrupt, message, file: file, line: line)
+                                 file: StaticString = #file, line: UInt = #line) {
+    XCTAssertTrue(self.didInterrupt, message, file: file, line: line)
   }
 
   public func assertDidNotInterrupt(_ message: String = "Should not have failed.",
-                                      file: StaticString = #file, line: UInt = #line) {
-      XCTAssertFalse(self.didInterrupt, message, file: file, line: line)
+                                    file: StaticString = #file, line: UInt = #line) {
+    XCTAssertFalse(self.didInterrupt, message, file: file, line: line)
   }
 
   public func assertDidNotComplete(_ message: String = "Should not have completed",
-                                     file: StaticString = #file, line: UInt = #line) {
-      XCTAssertFalse(self.didComplete, message, file: file, line: line)
+                                   file: StaticString = #file, line: UInt = #line) {
+    XCTAssertFalse(self.didComplete, message, file: file, line: line)
   }
 
   public func assertDidEmitValue(_ message: String = "Should have emitted at least one value.",
-                                   file: StaticString = #file, line: UInt = #line) {
-      XCTAssert(self.values.count > 0, message, file: file, line: line)
+                                 file: StaticString = #file, line: UInt = #line) {
+    XCTAssert(self.values.count > 0, message, file: file, line: line)
   }
 
   public func assertDidNotEmitValue(_ message: String = "Should not have emitted any values.",
-                                      file: StaticString = #file, line: UInt = #line) {
-      XCTAssertEqual(0, self.values.count, message, file: file, line: line)
+                                    file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(0, self.values.count, message, file: file, line: line)
   }
 
   public func assertDidTerminate(
     _ message: String = "Should have terminated, i.e. completed/failed/interrupted.",
     file: StaticString = #file, line: UInt = #line) {
-      XCTAssertTrue(self.didFail || self.didComplete || self.didInterrupt, message, file: file, line: line)
+    XCTAssertTrue(self.didFail || self.didComplete || self.didInterrupt, message, file: file, line: line)
   }
 
   public func assertDidNotTerminate(
     _ message: String = "Should not have terminated, i.e. completed/failed/interrupted.",
     file: StaticString = #file, line: UInt = #line) {
-      XCTAssertTrue(!self.didFail && !self.didComplete && !self.didInterrupt, message, file: file, line: line)
+    XCTAssertTrue(!self.didFail && !self.didComplete && !self.didInterrupt, message, file: file, line: line)
   }
 
   public func assertValueCount(_ count: Int, _ message: String? = nil,
-                                 file: StaticString = #file, line: UInt = #line) {
-      XCTAssertEqual(count, self.values.count, message ?? "Should have emitted \(count) values",
-        file: file, line: line)
+                               file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(count, self.values.count, message ?? "Should have emitted \(count) values",
+      file: file, line: line)
   }
 }
 
 extension TestObserver where Value: Equatable {
   public func assertValue(_ value: Value, _ message: String? = nil,
-                            file: StaticString = #file, line: UInt = #line) {
+                          file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
     XCTAssertEqual(value, self.lastValue, message ?? "A single value of \(value) should have been emitted",
-                   file: file, line: line)
+      file: file, line: line)
   }
 
   public func assertLastValue(_ value: Value, _ message: String? = nil,
-                                file: StaticString = #file, line: UInt = #line) {
+                              file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(value, self.lastValue, message ?? "Last emitted value is equal to \(value).",
-                   file: file, line: line)
+      file: file, line: line)
   }
 
   public func assertValues(_ values: [Value], _ message: String = "",
-                             file: StaticString = #file, line: UInt = #line) {
-      XCTAssertEqual(values, self.values, message, file: file, line: line)
+                           file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(values, self.values, message, file: file, line: line)
   }
 }
 
 extension TestObserver where Error: Equatable {
   public func assertFailed(_ expectedError: Error, message: String = "",
-                             file: StaticString = #file, line: UInt = #line) {
-      XCTAssertEqual(expectedError, self.failedError, message, file: file, line: line)
+                           file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(expectedError, self.failedError, message, file: file, line: line)
   }
 }

--- a/ReactiveExtensions/test-helpers/TestObserver.swift
+++ b/ReactiveExtensions/test-helpers/TestObserver.swift
@@ -2,7 +2,7 @@ import XCTest
 import ReactiveSwift
 
 /**
- A `TestObserver` is a wrapper around an `Observer` that saves all events to an internal array so that
+ A `TestObserver` is a wrapper around an `Observer` that saves all events to an public array so that
  assertions can be made on a signal's behavior. To use, just create an instance of `TestObserver` that
  matches the type of signal/producer you are testing, and observer/start your signal by feeding it the
  wrapped observer. For example,
@@ -16,12 +16,12 @@ import ReactiveSwift
  test.assertValues([1, 2, 3])
  ```
  */
-internal final class TestObserver <Value, Error: Swift.Error> {
+public final class TestObserver <Value, Error: Swift.Error> {
 
-  internal private(set) var events: [Signal<Value, Error>.Event] = []
-  internal private(set) var observer: Signal<Value, Error>.Observer!
+  public private(set) var events: [Signal<Value, Error>.Event] = []
+  public private(set) var observer: Signal<Value, Error>.Observer!
 
-  internal init() {
+  public init() {
     self.observer = Signal<Value, Error>.Observer(action)
   }
 
@@ -30,93 +30,93 @@ internal final class TestObserver <Value, Error: Swift.Error> {
   }
 
   /// Get all of the next values emitted by the signal.
-  internal var values: [Value] {
+  public var values: [Value] {
     return self.events.filter { $0.isValue }.map { $0.value! }
   }
 
   /// Get the last value emitted by the signal.
-  internal var lastValue: Value? {
+  public var lastValue: Value? {
     return self.values.last
   }
 
   /// `true` if at least one `.Next` value has been emitted.
-  internal var didEmitValue: Bool {
+  public var didEmitValue: Bool {
     return self.values.count > 0
   }
 
   /// The failed error if the signal has failed.
-  internal var failedError: Error? {
+  public var failedError: Error? {
     return self.events.filter { $0.isFailed }.map { $0.error! }.first
   }
 
   /// `true` if a `.Failed` event has been emitted.
-  internal var didFail: Bool {
+  public var didFail: Bool {
     return self.failedError != nil
   }
 
   /// `true` if a `.Completed` event has been emitted.
-  internal var didComplete: Bool {
+  public var didComplete: Bool {
     return self.events.filter { $0.isCompleted }.count > 0
   }
 
   /// `true` if a .Interrupt` event has been emitted.
-  internal var didInterrupt: Bool {
+  public var didInterrupt: Bool {
     return self.events.filter { $0.isInterrupted }.count > 0
   }
 
-  internal func assertDidComplete(_ message: String = "Should have completed.",
+  public func assertDidComplete(_ message: String = "Should have completed.",
                                   file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didComplete, message, file: file, line: line)
   }
 
-  internal func assertDidFail(_ message: String = "Should have failed.",
+  public func assertDidFail(_ message: String = "Should have failed.",
                               file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didFail, message, file: file, line: line)
   }
 
-  internal func assertDidNotFail(_ message: String = "Should not have failed.",
+  public func assertDidNotFail(_ message: String = "Should not have failed.",
                                  file: StaticString = #file, line: UInt = #line) {
       XCTAssertFalse(self.didFail, message, file: file, line: line)
   }
 
-  internal func assertDidInterrupt(_ message: String = "Should have failed.",
+  public func assertDidInterrupt(_ message: String = "Should have failed.",
                                    file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didInterrupt, message, file: file, line: line)
   }
 
-  internal func assertDidNotInterrupt(_ message: String = "Should not have failed.",
+  public func assertDidNotInterrupt(_ message: String = "Should not have failed.",
                                       file: StaticString = #file, line: UInt = #line) {
       XCTAssertFalse(self.didInterrupt, message, file: file, line: line)
   }
 
-  internal func assertDidNotComplete(_ message: String = "Should not have completed",
+  public func assertDidNotComplete(_ message: String = "Should not have completed",
                                      file: StaticString = #file, line: UInt = #line) {
       XCTAssertFalse(self.didComplete, message, file: file, line: line)
   }
 
-  internal func assertDidEmitValue(_ message: String = "Should have emitted at least one value.",
+  public func assertDidEmitValue(_ message: String = "Should have emitted at least one value.",
                                    file: StaticString = #file, line: UInt = #line) {
       XCTAssert(self.values.count > 0, message, file: file, line: line)
   }
 
-  internal func assertDidNotEmitValue(_ message: String = "Should not have emitted any values.",
+  public func assertDidNotEmitValue(_ message: String = "Should not have emitted any values.",
                                       file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(0, self.values.count, message, file: file, line: line)
   }
 
-  internal func assertDidTerminate(
+  public func assertDidTerminate(
     _ message: String = "Should have terminated, i.e. completed/failed/interrupted.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(self.didFail || self.didComplete || self.didInterrupt, message, file: file, line: line)
   }
 
-  internal func assertDidNotTerminate(
+  public func assertDidNotTerminate(
     _ message: String = "Should not have terminated, i.e. completed/failed/interrupted.",
     file: StaticString = #file, line: UInt = #line) {
       XCTAssertTrue(!self.didFail && !self.didComplete && !self.didInterrupt, message, file: file, line: line)
   }
 
-  internal func assertValueCount(_ count: Int, _ message: String? = nil,
+  public func assertValueCount(_ count: Int, _ message: String? = nil,
                                  file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(count, self.values.count, message ?? "Should have emitted \(count) values",
         file: file, line: line)
@@ -124,27 +124,27 @@ internal final class TestObserver <Value, Error: Swift.Error> {
 }
 
 extension TestObserver where Value: Equatable {
-  internal func assertValue(_ value: Value, _ message: String? = nil,
+  public func assertValue(_ value: Value, _ message: String? = nil,
                             file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(1, self.values.count, "A single item should have been emitted.", file: file, line: line)
     XCTAssertEqual(value, self.lastValue, message ?? "A single value of \(value) should have been emitted",
                    file: file, line: line)
   }
 
-  internal func assertLastValue(_ value: Value, _ message: String? = nil,
+  public func assertLastValue(_ value: Value, _ message: String? = nil,
                                 file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(value, self.lastValue, message ?? "Last emitted value is equal to \(value).",
                    file: file, line: line)
   }
 
-  internal func assertValues(_ values: [Value], _ message: String = "",
+  public func assertValues(_ values: [Value], _ message: String = "",
                              file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(values, self.values, message, file: file, line: line)
   }
 }
 
 extension TestObserver where Error: Equatable {
-  internal func assertFailed(_ expectedError: Error, message: String = "",
+  public func assertFailed(_ expectedError: Error, message: String = "",
                              file: StaticString = #file, line: UInt = #line) {
       XCTAssertEqual(expectedError, self.failedError, message, file: file, line: line)
   }


### PR DESCRIPTION
This PR makes some minor changes to support Carthage in our main app.

That change is described here: https://github.com/kickstarter/ios-oss/pull/658

In particular it was necessary to:

- Pin ReactiveSwift's submodule hash in this framework to the commit tagged as `4.0.0`.
- Change the visibility of `TestObserver` so that it may be used in our main app's test targets without requiring the `@testable import` to access `internal` classes and properties.
- Lastly it sets the build system to `Legacy`. This is a workaround for Carthage and does not have any major drawbacks for us so it seems reasonable for me to switch it for this framework.