### PR TITLE
Update to Swift 5 and Xcode 10.2

### DIFF
--- a/ReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ReactiveExtensions.xcodeproj/project.pbxproj
@@ -880,6 +880,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = CA43C6591BB35FCF00C180DA;
@@ -1476,7 +1477,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.ReactiveExtensions;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1495,7 +1495,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.ReactiveExtensions;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1583,7 +1582,7 @@
 				PRODUCT_NAME = ReactiveExtensions;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.4;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1639,7 +1638,7 @@
 				PRODUCT_NAME = ReactiveExtensions;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.4;
 				VALIDATE_PRODUCT = YES;

--- a/ReactiveExtensions/helpers/DispatchTimeInterval-Extensions.swift
+++ b/ReactiveExtensions/helpers/DispatchTimeInterval-Extensions.swift
@@ -2,30 +2,19 @@ import Foundation
 
 extension DispatchTimeInterval {
   internal var timeInterval: TimeInterval {
-    #if swift(>=3.2)
-      switch self {
-      case let .seconds(s):
-        return TimeInterval(s)
-      case let .milliseconds(ms):
-        return TimeInterval(TimeInterval(ms) / 1000.0)
-      case let .microseconds(us):
-        return TimeInterval(Int64(us) * Int64(NSEC_PER_USEC)) / TimeInterval(NSEC_PER_SEC)
-      case let .nanoseconds(ns):
-        return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
-      case .never:
-        return .infinity
-      }
-    #else
-      switch self {
-      case let .seconds(s):
-        return TimeInterval(s)
-      case let .milliseconds(ms):
-        return TimeInterval(TimeInterval(ms) / 1000.0)
-      case let .microseconds(us):
-        return TimeInterval(Int64(us) * Int64(NSEC_PER_USEC)) / TimeInterval(NSEC_PER_SEC)
-      case let .nanoseconds(ns):
-        return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
-      }
-    #endif
+    switch self {
+    case let .seconds(s):
+      return TimeInterval(s)
+    case let .milliseconds(ms):
+      return TimeInterval(TimeInterval(ms) / 1000.0)
+    case let .microseconds(us):
+      return TimeInterval(Int64(us) * Int64(NSEC_PER_USEC)) / TimeInterval(NSEC_PER_SEC)
+    case let .nanoseconds(ns):
+      return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
+    case .never:
+      return .infinity
+    @unknown default:
+      fatalError()
+    }
   }
 }

--- a/ReactiveExtensions/operators/Enumerated.swift
+++ b/ReactiveExtensions/operators/Enumerated.swift
@@ -12,7 +12,6 @@ extension Signal {
 
    - returns: The enumerated signal.
    */
-  // swiftlint:disable:next valid_docs
   public func enumerated() -> Signal<(idx: Int, value: Value), Error> {
 
     let initial: (idx: Int, value: Value?) = (-1, nil)

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "10.2.0"
+      xcode: "10.2.1"
     working_directory: ~/ReactiveExtensions
     environment:
       CIRCLE_ARTIFACTS: /tmp

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "10.1.0"
+      xcode: "10.2.0"
     working_directory: ~/ReactiveExtensions
     environment:
       CIRCLE_ARTIFACTS: /tmp
@@ -18,8 +18,8 @@ jobs:
       - run: set -o pipefail &&
           swiftlint lint --strict --reporter json |
           tee $CIRCLE_ARTIFACTS/swiftlint-report.json
-      - run: bin/test iOS 11.2
-      - run: bin/test iOS 12.1
+      - run: bin/test iOS 11.4
+      - run: bin/test iOS 12.2
 
       - store_artifacts:
           path: /tmp/swiftlint-report.json


### PR DESCRIPTION
As the title suggests! This updates ReactiveExtensions to Swift 5 and Xcode 10.2. It also updates the ReactiveSwift dependency to [5.0.1](https://github.com/ReactiveCocoa/ReactiveSwift/releases/tag/5.0.1) to match what we will have in the main app.

This does _not_ silence these sorts of warnings, I'd like to see if we can do that with a code-formatter, or just disable the check as I don't know that they're that important.

<img width="447" alt="Screen Shot 2019-05-24 at 11 13 15 AM" src="https://user-images.githubusercontent.com/3735375/58350623-464a4500-7e1b-11e9-9449-79de64c73573.png">
