### PR TITLE
Update to ReactiveSwift 6.0.0

### DIFF
--- a/ReactiveExtensions.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
+++ b/ReactiveExtensions.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
@@ -1,7 +1,6 @@
 import PlaygroundSupport
 import ReactiveExtensions
 import ReactiveSwift
-import Result
 
 /*:
  # Reactive Extensions
@@ -73,7 +72,7 @@ import Result
  useful for transforming user input into a stream of actions, e.g.:
  */
 
-let incrementClicks = SignalProducer<(), NoError>([(), (), (), ()])
+let incrementClicks = SignalProducer<(), Never>([(), (), (), ()])
 incrementClicks
   .mapConst(1)
   .allValues()
@@ -82,7 +81,7 @@ incrementClicks
  This stream could be merged with a corresponding decrementing stream:
  */
 
-let decrementClicks = SignalProducer<(), NoError>([(), (), ()])
+let decrementClicks = SignalProducer<(), Never>([(), (), ()])
 incrementClicks.mapConst(1)
   .mergeWith(decrementClicks.mapConst(-1))
   .allValues()
@@ -108,7 +107,7 @@ clicksTotal.allValues()
  ### `demoteErrors`
 
  There's an operator in core RAC called `promoteErrors` that promotes a signal that is
- parameterized by the `NoError` type into one that is parameterized by some error. The signal
+ parameterized by the `Never` type into one that is parameterized by some error. The signal
  won’t actually error, but at least its type can now align with some other signal in order to
  make `flatMap`, `combineLatest`, etc. with other signals work. E.g.
  */
@@ -121,7 +120,7 @@ func fetchDataThatCouldError(_ x: Int) -> SignalProducer<Int, NSError> {
   return SignalProducer(error: NSError(domain: "", code: 1, userInfo: nil))
 }
 
-clicksTotal.promoteErrors(NSError.self)
+clicksTotal.promoteError(NSError.self)
   .flatMap(fetchDataThatCouldError)
   .allValues()
 
@@ -154,7 +153,7 @@ clicksTotal
  API request that returns an array of objects.
  */
 
-let response = SignalProducer<[Int], NoError>(value: [1, 2, 3, 4, 5, 6, 7])
+let response = SignalProducer<[Int], Never>(value: [1, 2, 3, 4, 5, 6, 7])
 response
   .uncollect()
   .filter { x in x % 2 == 0 }
@@ -173,7 +172,7 @@ response
 let scheduler = QueueScheduler(qos: .background, name: "bg", targeting: .global(qos: .background))
 
 // Returns a signal that emits `x` three times, but each staggered by .01 seconds.
-func staggeredTriple(x: Int) -> SignalProducer<Int, NoError> {
+func staggeredTriple(x: Int) -> SignalProducer<Int, Never> {
   return SignalProducer(value: x).delay(0.01, on: scheduler)
     .mergeWith(SignalProducer(value: x).delay(0.02, on: scheduler))
     .mergeWith(SignalProducer(value: x).delay(0.03, on: scheduler))
@@ -183,8 +182,8 @@ func staggeredTriple(x: Int) -> SignalProducer<Int, NoError> {
  With this function we can describe each of the `flatMap` operations. The first is the simplest:
  */
 
-SignalProducer<Int, NoError>([1, 2, 3])
-  .flatMap(.concat, transform: staggeredTriple)
+SignalProducer<Int, Never>([1, 2, 3])
+  .flatMap(.concat, staggeredTriple)
   .allValues()
 
 /*:
@@ -195,8 +194,8 @@ SignalProducer<Int, NoError>([1, 2, 3])
  The next simplest is `flatMap(.Merge)`:
  */
 
-SignalProducer<Int, NoError>([1, 2, 3])
-  .flatMap(.merge, transform: staggeredTriple)
+SignalProducer<Int, Never>([1, 2, 3])
+  .flatMap(.merge, staggeredTriple)
   .allValues()
 
 /*:
@@ -207,8 +206,8 @@ SignalProducer<Int, NoError>([1, 2, 3])
  Finally, perhaps the most complicated, but also most useful, is `flatMap(.Latest)`:
  */
 
-SignalProducer<Int, NoError>([1, 2, 3])
-  .flatMap(.latest, transform: staggeredTriple)
+SignalProducer<Int, Never>([1, 2, 3])
+  .flatMap(.latest, staggeredTriple)
   .allValues()
 
 /*:
@@ -222,21 +221,17 @@ SignalProducer<Int, NoError>([1, 2, 3])
  more descriptive names:
  */
 
-SignalProducer<Int, NoError>([1, 2, 3])
+SignalProducer<Int, Never>([1, 2, 3])
   .mergeMap(staggeredTriple)
   .allValues()
 
-SignalProducer<Int, NoError>([1, 2, 3])
+SignalProducer<Int, Never>([1, 2, 3])
   .concatMap(staggeredTriple)
   .allValues()
 
-SignalProducer<Int, NoError>([1, 2, 3])
+SignalProducer<Int, Never>([1, 2, 3])
   .switchMap(staggeredTriple)
   .allValues()
-
-
-
-
 
 // Playground configuration
 PlaygroundPage.current.needsIndefiniteExecution = true

--- a/ReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ReactiveExtensions.xcodeproj/project.pbxproj
@@ -52,14 +52,10 @@
 		A7983B5F1C2AF8B0003A1ABE /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7983B5E1C2AF8B0003A1ABE /* UILabel.swift */; };
 		A7983B631C2AF8D4003A1ABE /* UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7983B621C2AF8D4003A1ABE /* UIControl.swift */; };
 		A7983B8D1C2AFB1D003A1ABE /* ReactiveExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43C6631BB35FCF00C180DA /* ReactiveExtensions.framework */; };
-		A79BE79C1E0709990077A9B2 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE77A1E07091D0077A9B2 /* Result.framework */; };
 		A79BE79D1E07099D0077A9B2 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE75B1E0709020077A9B2 /* ReactiveSwift.framework */; };
 		A79BE7A61E070E700077A9B2 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE75B1E0709020077A9B2 /* ReactiveSwift.framework */; };
-		A79BE7A71E070E740077A9B2 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE77A1E07091D0077A9B2 /* Result.framework */; };
 		A79BE7AA1E0711500077A9B2 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE7611E0709020077A9B2 /* ReactiveSwift.framework */; };
-		A79BE7AD1E0711570077A9B2 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE77E1E07091D0077A9B2 /* Result.framework */; };
 		A79BE7B21E0711650077A9B2 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE7611E0709020077A9B2 /* ReactiveSwift.framework */; };
-		A79BE7B31E0711690077A9B2 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE77E1E07091D0077A9B2 /* Result.framework */; };
 		A7A015D71CBDA99100C4B821 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A015D61CBDA99100C4B821 /* TakeUntil.swift */; };
 		A7A015D81CBDA99100C4B821 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A015D61CBDA99100C4B821 /* TakeUntil.swift */; };
 		A7B11A561D78A43D00A5036E /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B11A551D78A43D00A5036E /* Scan.swift */; };
@@ -232,68 +228,12 @@
 			remoteGlobalIDString = 7DFBED031CDB8C9500EE435B;
 			remoteInfo = "ReactiveSwift-tvOSTests";
 		};
-		A79BE7751E07091D0077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D45480571A9572F5009D7229;
-			remoteInfo = "Result-Mac";
-		};
-		A79BE7771E07091D0077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D45480671A9572F5009D7229;
-			remoteInfo = "Result-MacTests";
-		};
-		A79BE7791E07091D0077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D454807D1A957361009D7229;
-			remoteInfo = "Result-iOS";
-		};
-		A79BE77B1E07091D0077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D45480871A957362009D7229;
-			remoteInfo = "Result-iOSTests";
-		};
-		A79BE77D1E07091D0077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 57FCDE471BA280DC00130C48;
-			remoteInfo = "Result-tvOS";
-		};
-		A79BE77F1E07091D0077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 57FCDE541BA280E000130C48;
-			remoteInfo = "Result-tvOSTests";
-		};
-		A79BE7811E07091D0077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = D03579A31B2B788F005D26AE;
-			remoteInfo = "Result-watchOS";
-		};
 		A79BE7891E0709900077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = D047260B19E49F82006002AA;
 			remoteInfo = "ReactiveSwift-iOS";
-		};
-		A79BE79A1E0709940077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D454807C1A957361009D7229;
-			remoteInfo = "Result-iOS";
 		};
 		A79BE7A21E070E670077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -302,13 +242,6 @@
 			remoteGlobalIDString = D047260B19E49F82006002AA;
 			remoteInfo = "ReactiveSwift-iOS";
 		};
-		A79BE7A41E070E6B0077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D454807C1A957361009D7229;
-			remoteInfo = "Result-iOS";
-		};
 		A79BE7A81E07114A0077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
@@ -316,26 +249,12 @@
 			remoteGlobalIDString = 57A4D1AF1BA13D7A00F7D4B1;
 			remoteInfo = "ReactiveSwift-tvOS";
 		};
-		A79BE7AB1E0711530077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 57FCDE3C1BA280DC00130C48;
-			remoteInfo = "Result-tvOS";
-		};
 		A79BE7AE1E07115E0077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 57A4D1AF1BA13D7A00F7D4B1;
 			remoteInfo = "ReactiveSwift-tvOS";
-		};
-		A79BE7B01E0711610077A9B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 57FCDE3C1BA280DC00130C48;
-			remoteInfo = "Result-tvOS";
 		};
 		A7DB1D441C9F4E3F008244DA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -389,7 +308,6 @@
 		A7983B621C2AF8D4003A1ABE /* UIControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControl.swift; sourceTree = "<group>"; };
 		A7983B881C2AFB1C003A1ABE /* ReactiveExtensions-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ReactiveExtensions-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReactiveSwift.xcodeproj; path = Frameworks/ReactiveSwift/ReactiveSwift.xcodeproj; sourceTree = "<group>"; };
-		A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Result.xcodeproj; path = Frameworks/ReactiveSwift/Carthage/Checkouts/Result/Result.xcodeproj; sourceTree = "<group>"; };
 		A7A015D61CBDA99100C4B821 /* TakeUntil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TakeUntil.swift; sourceTree = "<group>"; };
 		A7B11A551D78A43D00A5036E /* Scan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scan.swift; sourceTree = "<group>"; };
 		A7C510451C2720D500C59136 /* Sort.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Sort.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -464,7 +382,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A79BE7A71E070E740077A9B2 /* Result.framework in Frameworks */,
 				A79BE7A61E070E700077A9B2 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -473,7 +390,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A79BE7B31E0711690077A9B2 /* Result.framework in Frameworks */,
 				A79BE7B21E0711650077A9B2 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -483,7 +399,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				A79BE79D1E07099D0077A9B2 /* ReactiveSwift.framework in Frameworks */,
-				A79BE79C1E0709990077A9B2 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -500,7 +415,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A79BE7AD1E0711570077A9B2 /* Result.framework in Frameworks */,
 				A79BE7AA1E0711500077A9B2 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -563,20 +477,6 @@
 				A79BE75F1E0709020077A9B2 /* ReactiveSwift.framework */,
 				A79BE7611E0709020077A9B2 /* ReactiveSwift.framework */,
 				A79BE7631E0709020077A9B2 /* ReactiveSwiftTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		A79BE76B1E07091D0077A9B2 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				A79BE7761E07091D0077A9B2 /* Result.framework */,
-				A79BE7781E07091D0077A9B2 /* Result-MacTests.xctest */,
-				A79BE77A1E07091D0077A9B2 /* Result.framework */,
-				A79BE77C1E07091D0077A9B2 /* Result-iOSTests.xctest */,
-				A79BE77E1E07091D0077A9B2 /* Result.framework */,
-				A79BE7801E07091D0077A9B2 /* Result-tvOSTests.xctest */,
-				A79BE7821E07091D0077A9B2 /* Result.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -644,7 +544,6 @@
 			isa = PBXGroup;
 			children = (
 				A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */,
-				A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -755,7 +654,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				A79BE7A51E070E6B0077A9B2 /* PBXTargetDependency */,
 				A79BE7A31E070E670077A9B2 /* PBXTargetDependency */,
 			);
 			name = "ReactiveExtensions-TestHelpers-iOS";
@@ -775,7 +673,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				A79BE7B11E0711610077A9B2 /* PBXTargetDependency */,
 				A79BE7AF1E07115E0077A9B2 /* PBXTargetDependency */,
 			);
 			name = "ReactiveExtensions-TestHelpers-tvOS";
@@ -795,7 +692,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				A79BE79B1E0709940077A9B2 /* PBXTargetDependency */,
 				A79BE78A1E0709900077A9B2 /* PBXTargetDependency */,
 			);
 			name = "ReactiveExtensions-iOS";
@@ -834,7 +730,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				A79BE7AC1E0711530077A9B2 /* PBXTargetDependency */,
 				A79BE7A91E07114A0077A9B2 /* PBXTargetDependency */,
 			);
 			name = "ReactiveExtensions-tvOS";
@@ -890,10 +785,6 @@
 				{
 					ProductGroup = A79BE7481E0709020077A9B2 /* Products */;
 					ProjectRef = A79BE7471E0709020077A9B2 /* ReactiveSwift.xcodeproj */;
-				},
-				{
-					ProductGroup = A79BE76B1E07091D0077A9B2 /* Products */;
-					ProjectRef = A79BE76A1E07091D0077A9B2 /* Result.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -956,55 +847,6 @@
 			fileType = wrapper.cfbundle;
 			path = ReactiveSwiftTests.xctest;
 			remoteRef = A79BE7621E0709020077A9B2 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A79BE7761E07091D0077A9B2 /* Result.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Result.framework;
-			remoteRef = A79BE7751E07091D0077A9B2 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A79BE7781E07091D0077A9B2 /* Result-MacTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "Result-MacTests.xctest";
-			remoteRef = A79BE7771E07091D0077A9B2 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A79BE77A1E07091D0077A9B2 /* Result.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Result.framework;
-			remoteRef = A79BE7791E07091D0077A9B2 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A79BE77C1E07091D0077A9B2 /* Result-iOSTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "Result-iOSTests.xctest";
-			remoteRef = A79BE77B1E07091D0077A9B2 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A79BE77E1E07091D0077A9B2 /* Result.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Result.framework;
-			remoteRef = A79BE77D1E07091D0077A9B2 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A79BE7801E07091D0077A9B2 /* Result-tvOSTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "Result-tvOSTests.xctest";
-			remoteRef = A79BE77F1E07091D0077A9B2 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A79BE7821E07091D0077A9B2 /* Result.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Result.framework;
-			remoteRef = A79BE7811E07091D0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -1262,40 +1104,20 @@
 			name = "ReactiveSwift-iOS";
 			targetProxy = A79BE7891E0709900077A9B2 /* PBXContainerItemProxy */;
 		};
-		A79BE79B1E0709940077A9B2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Result-iOS";
-			targetProxy = A79BE79A1E0709940077A9B2 /* PBXContainerItemProxy */;
-		};
 		A79BE7A31E070E670077A9B2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ReactiveSwift-iOS";
 			targetProxy = A79BE7A21E070E670077A9B2 /* PBXContainerItemProxy */;
-		};
-		A79BE7A51E070E6B0077A9B2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Result-iOS";
-			targetProxy = A79BE7A41E070E6B0077A9B2 /* PBXContainerItemProxy */;
 		};
 		A79BE7A91E07114A0077A9B2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ReactiveSwift-tvOS";
 			targetProxy = A79BE7A81E07114A0077A9B2 /* PBXContainerItemProxy */;
 		};
-		A79BE7AC1E0711530077A9B2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Result-tvOS";
-			targetProxy = A79BE7AB1E0711530077A9B2 /* PBXContainerItemProxy */;
-		};
 		A79BE7AF1E07115E0077A9B2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ReactiveSwift-tvOS";
 			targetProxy = A79BE7AE1E07115E0077A9B2 /* PBXContainerItemProxy */;
-		};
-		A79BE7B11E0711610077A9B2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Result-tvOS";
-			targetProxy = A79BE7B01E0711610077A9B2 /* PBXContainerItemProxy */;
 		};
 		A7DB1D451C9F4E3F008244DA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/ReactiveExtensions/UIKit/NSLayoutConstraint.swift
+++ b/ReactiveExtensions/UIKit/NSLayoutConstraint.swift
@@ -7,7 +7,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: NSLayoutConstraint {
-  public var constant: Signal<CGFloat, NoError> {
+  public var constant: Signal<CGFloat, Never> {
     nonmutating set {
       let prop: MutableProperty<CGFloat> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/NSLayoutConstraint.swift
+++ b/ReactiveExtensions/UIKit/NSLayoutConstraint.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/NSLayoutConstraintTests.swift
+++ b/ReactiveExtensions/UIKit/NSLayoutConstraintTests.swift
@@ -9,7 +9,7 @@ final class NSLayoutConstraintTests: XCTestCase {
   let constraint = NSLayoutConstraint()
 
   func testConstant() {
-    let (signal, observer) = Signal<CGFloat, NoError>.pipe()
+    let (signal, observer) = Signal<CGFloat, Never>.pipe()
     constraint.rac.constant = signal
 
     observer.send(value: 1.0)

--- a/ReactiveExtensions/UIKit/NSLayoutConstraintTests.swift
+++ b/ReactiveExtensions/UIKit/NSLayoutConstraintTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/NSObject.swift
+++ b/ReactiveExtensions/UIKit/NSObject.swift
@@ -12,7 +12,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: NSObject {
-  public var accessibilityElementsHidden: Signal<Bool, NoError> {
+  public var accessibilityElementsHidden: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object,
@@ -28,7 +28,7 @@ public extension Rac where Object: NSObject {
     }
   }
 
-  public var accessibilityHint: Signal<String, NoError> {
+  public var accessibilityHint: Signal<String, Never> {
     nonmutating set {
       let prop: MutableProperty<String> = lazyMutableProperty(
         object,
@@ -44,7 +44,7 @@ public extension Rac where Object: NSObject {
     }
   }
 
-  public var accessibilityLabel: Signal<String, NoError> {
+  public var accessibilityLabel: Signal<String, Never> {
     nonmutating set {
       let prop: MutableProperty<String> = lazyMutableProperty(
         object,
@@ -60,7 +60,7 @@ public extension Rac where Object: NSObject {
     }
   }
 
-  public var accessibilityTraits: Signal<UIAccessibilityTraits, NoError> {
+  public var accessibilityTraits: Signal<UIAccessibilityTraits, Never> {
     nonmutating set {
       let prop: MutableProperty<UIAccessibilityTraits> = lazyMutableProperty(
         object,
@@ -76,7 +76,7 @@ public extension Rac where Object: NSObject {
     }
   }
 
-  public var accessibilityValue: Signal<String, NoError> {
+  public var accessibilityValue: Signal<String, Never> {
     nonmutating set {
       let prop: MutableProperty<String> = lazyMutableProperty(
         object,
@@ -92,7 +92,7 @@ public extension Rac where Object: NSObject {
     }
   }
 
-  public var isAccessibilityElement: Signal<Bool, NoError> {
+  public var isAccessibilityElement: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/NSObject.swift
+++ b/ReactiveExtensions/UIKit/NSObject.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UIActivityIndicator.swift
+++ b/ReactiveExtensions/UIKit/UIActivityIndicator.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UIActivityIndicator.swift
+++ b/ReactiveExtensions/UIKit/UIActivityIndicator.swift
@@ -7,7 +7,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UIActivityIndicatorView {
-  public var animating: Signal<Bool, NoError> {
+  public var animating: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UIActivityIndicatorTests.swift
+++ b/ReactiveExtensions/UIKit/UIActivityIndicatorTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UIActivityIndicatorTests.swift
+++ b/ReactiveExtensions/UIKit/UIActivityIndicatorTests.swift
@@ -9,7 +9,7 @@ final class UIActivityIndicatorTests: XCTestCase {
   let indicator = UIActivityIndicatorView()
 
   func testAnimating() {
-    let (signal, observer) = Signal<Bool, NoError>.pipe()
+    let (signal, observer) = Signal<Bool, Never>.pipe()
     indicator.rac.animating = signal
 
     observer.send(value: true)

--- a/ReactiveExtensions/UIKit/UIBarButtonItem.swift
+++ b/ReactiveExtensions/UIKit/UIBarButtonItem.swift
@@ -7,7 +7,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UIBarButtonItem {
-  public var enabled: Signal<Bool, NoError> {
+  public var enabled: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UIBarButtonItem.swift
+++ b/ReactiveExtensions/UIKit/UIBarButtonItem.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UIBarButtonItemTests.swift
+++ b/ReactiveExtensions/UIKit/UIBarButtonItemTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UIBarButtonItemTests.swift
+++ b/ReactiveExtensions/UIKit/UIBarButtonItemTests.swift
@@ -9,7 +9,7 @@ final class UIBarButtonItemTests: XCTestCase {
   let barButtonItem = UIBarButtonItem()
 
   func testEnabled() {
-    let (signal, observer) = Signal<Bool, NoError>.pipe()
+    let (signal, observer) = Signal<Bool, Never>.pipe()
     barButtonItem.rac.enabled = signal
 
     observer.send(value: true)

--- a/ReactiveExtensions/UIKit/UIButton.swift
+++ b/ReactiveExtensions/UIKit/UIButton.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UIButton.swift
+++ b/ReactiveExtensions/UIKit/UIButton.swift
@@ -8,7 +8,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UIButton {
-  public var title: Signal<String, NoError> {
+  public var title: Signal<String, Never> {
     nonmutating set {
       let prop: MutableProperty<String> = lazyMutableProperty(
         object,
@@ -24,7 +24,7 @@ public extension Rac where Object: UIButton {
     }
   }
 
-  public var attributedTitle: Signal<NSAttributedString, NoError> {
+  public var attributedTitle: Signal<NSAttributedString, Never> {
     nonmutating set {
       let prop: MutableProperty<NSAttributedString> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UIButtonTests.swift
+++ b/ReactiveExtensions/UIKit/UIButtonTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UIButtonTests.swift
+++ b/ReactiveExtensions/UIKit/UIButtonTests.swift
@@ -9,7 +9,7 @@ internal final class UIButtonTests: XCTestCase {
   private let button = UIButton()
 
   func testTitle() {
-    let (signal, observer) = Signal<String, NoError>.pipe()
+    let (signal, observer) = Signal<String, Never>.pipe()
     button.rac.title = signal
 
     observer.send(value: "Hello")

--- a/ReactiveExtensions/UIKit/UIControl.swift
+++ b/ReactiveExtensions/UIKit/UIControl.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UIControl.swift
+++ b/ReactiveExtensions/UIKit/UIControl.swift
@@ -8,7 +8,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UIControl {
-  public var enabled: Signal<Bool, NoError> {
+  public var enabled: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(object, key: &Associations.enabled,
         setter: { [weak object] in object?.isEnabled = $0 },
@@ -22,7 +22,7 @@ public extension Rac where Object: UIControl {
     }
   }
 
-  public var selected: Signal<Bool, NoError> {
+  public var selected: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object, key: &Associations.selected,

--- a/ReactiveExtensions/UIKit/UIControlTests.swift
+++ b/ReactiveExtensions/UIKit/UIControlTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UIControlTests.swift
+++ b/ReactiveExtensions/UIKit/UIControlTests.swift
@@ -10,7 +10,7 @@ final class UIControlTests: XCTestCase {
   let control = UIControl()
 
   func testEnabled() {
-    let (signal, observer) = Signal<Bool, NoError>.pipe()
+    let (signal, observer) = Signal<Bool, Never>.pipe()
     control.rac.enabled = signal
 
     observer.send(value: true)
@@ -24,7 +24,7 @@ final class UIControlTests: XCTestCase {
   }
 
   func testSelected() {
-    let (signal, observer) = Signal<Bool, NoError>.pipe()
+    let (signal, observer) = Signal<Bool, Never>.pipe()
     control.rac.selected = signal
 
     observer.send(value: true)

--- a/ReactiveExtensions/UIKit/UILabel.swift
+++ b/ReactiveExtensions/UIKit/UILabel.swift
@@ -10,7 +10,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UILabel {
-  public var attributedText: Signal<NSAttributedString, NoError> {
+  public var attributedText: Signal<NSAttributedString, Never> {
     nonmutating set {
       let prop: MutableProperty<NSAttributedString> = lazyMutableProperty(
         object,
@@ -26,7 +26,7 @@ public extension Rac where Object: UILabel {
     }
   }
 
-  public var text: Signal<String, NoError> {
+  public var text: Signal<String, Never> {
     nonmutating set {
       let prop: MutableProperty<String> = lazyMutableProperty(
         object,
@@ -42,7 +42,7 @@ public extension Rac where Object: UILabel {
     }
   }
 
-  public var font: Signal<UIFont, NoError> {
+  public var font: Signal<UIFont, Never> {
     nonmutating set {
       let prop: MutableProperty<UIFont> = lazyMutableProperty(
         object,
@@ -58,7 +58,7 @@ public extension Rac where Object: UILabel {
     }
   }
 
-  public var textColor: Signal<UIColor, NoError> {
+  public var textColor: Signal<UIColor, Never> {
     nonmutating set {
       let prop: MutableProperty<UIColor> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UILabel.swift
+++ b/ReactiveExtensions/UIKit/UILabel.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UILabelTests.swift
+++ b/ReactiveExtensions/UIKit/UILabelTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UILabelTests.swift
+++ b/ReactiveExtensions/UIKit/UILabelTests.swift
@@ -9,7 +9,7 @@ final class UILabelTests: XCTestCase {
   let label = UILabel()
 
   func testText() {
-    let (signal, observer) = Signal<String, NoError>.pipe()
+    let (signal, observer) = Signal<String, Never>.pipe()
     label.rac.text = signal
 
     observer.send(value: "The future")
@@ -20,7 +20,7 @@ final class UILabelTests: XCTestCase {
   }
 
   func testFont() {
-    let (signal, observer) = Signal<UIFont, NoError>.pipe()
+    let (signal, observer) = Signal<UIFont, Never>.pipe()
     label.rac.font = signal
 
     let font = UIFont.systemFont(ofSize: 16.0)
@@ -30,7 +30,7 @@ final class UILabelTests: XCTestCase {
   }
 
   func testTextColor() {
-    let (signal, observer) = Signal<UIColor, NoError>.pipe()
+    let (signal, observer) = Signal<UIColor, Never>.pipe()
     label.rac.textColor = signal
 
     let color = UIColor.red

--- a/ReactiveExtensions/UIKit/UINavigationItem.swift
+++ b/ReactiveExtensions/UIKit/UINavigationItem.swift
@@ -7,7 +7,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UINavigationItem {
-  public var title: Signal<String, NoError> {
+  public var title: Signal<String, Never> {
     nonmutating set {
       let prop: MutableProperty<String> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UINavigationItem.swift
+++ b/ReactiveExtensions/UIKit/UINavigationItem.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UIRefreshControl.swift
+++ b/ReactiveExtensions/UIKit/UIRefreshControl.swift
@@ -8,7 +8,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UIRefreshControl {
-  public var refreshing: Signal<Bool, NoError> {
+  public var refreshing: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UIRefreshControl.swift
+++ b/ReactiveExtensions/UIKit/UIRefreshControl.swift
@@ -1,6 +1,5 @@
 #if os(iOS)
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UIRefreshControlTests.swift
+++ b/ReactiveExtensions/UIKit/UIRefreshControlTests.swift
@@ -10,7 +10,7 @@ final class UIRefreshControlTests: XCTestCase {
   let control = UIRefreshControl()
 
   func testRefreshing() {
-    let (signal, observer) = Signal<Bool, NoError>.pipe()
+    let (signal, observer) = Signal<Bool, Never>.pipe()
     control.rac.refreshing = signal
 
     observer.send(value: true)

--- a/ReactiveExtensions/UIKit/UIRefreshControlTests.swift
+++ b/ReactiveExtensions/UIKit/UIRefreshControlTests.swift
@@ -1,7 +1,6 @@
 #if os(iOS)
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UIResponder.swift
+++ b/ReactiveExtensions/UIKit/UIResponder.swift
@@ -8,7 +8,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UIResponder {
-  public var becomeFirstResponder: Signal<(), NoError> {
+  public var becomeFirstResponder: Signal<(), Never> {
     nonmutating set {
       let prop: MutableProperty<()> = lazyMutableProperty(
         object,
@@ -26,7 +26,7 @@ public extension Rac where Object: UIResponder {
     }
   }
 
-  public var isFirstResponder: Signal<Bool, NoError> {
+  public var isFirstResponder: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UIResponder.swift
+++ b/ReactiveExtensions/UIKit/UIResponder.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UIResponderTests.swift
+++ b/ReactiveExtensions/UIKit/UIResponderTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UIResponderTests.swift
+++ b/ReactiveExtensions/UIKit/UIResponderTests.swift
@@ -19,7 +19,7 @@ final class UIResponderTests: XCTestCase {
   }
 
   func testBecomeFirstResponder() {
-    let (signal, observer) = Signal<(), NoError>.pipe()
+    let (signal, observer) = Signal<(), Never>.pipe()
     responder.rac.becomeFirstResponder = signal
 
     eventually(XCTAssertFalse(self.responder.isFirstResponder))
@@ -30,7 +30,7 @@ final class UIResponderTests: XCTestCase {
 
   func testIsFirstResponder() {
 
-    let (signal, observer) = Signal<Bool, NoError>.pipe()
+    let (signal, observer) = Signal<Bool, Never>.pipe()
     responder.rac.isFirstResponder = signal
 
     eventually(XCTAssertFalse(self.responder.isFirstResponder))

--- a/ReactiveExtensions/UIKit/UIStackView.swift
+++ b/ReactiveExtensions/UIKit/UIStackView.swift
@@ -8,7 +8,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UIStackView {
-  public var axis: Signal<NSLayoutConstraint.Axis, NoError> {
+  public var axis: Signal<NSLayoutConstraint.Axis, Never> {
     nonmutating set {
       let prop: MutableProperty<NSLayoutConstraint.Axis> = lazyMutableProperty(
         object, key: &Associations.axis,
@@ -22,7 +22,7 @@ public extension Rac where Object: UIStackView {
     }
   }
 
-  public var alignment: Signal<UIStackView.Alignment, NoError> {
+  public var alignment: Signal<UIStackView.Alignment, Never> {
     nonmutating set {
       let prop: MutableProperty<UIStackView.Alignment> = lazyMutableProperty(
         object, key: &Associations.alignment,

--- a/ReactiveExtensions/UIKit/UIStackView.swift
+++ b/ReactiveExtensions/UIKit/UIStackView.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UISwitch.swift
+++ b/ReactiveExtensions/UIKit/UISwitch.swift
@@ -1,6 +1,5 @@
 #if os(iOS)
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UISwitch.swift
+++ b/ReactiveExtensions/UIKit/UISwitch.swift
@@ -8,7 +8,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UISwitch {
-  public var on: Signal<Bool, NoError> {
+  public var on: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(
         object, key: &Associations.on,

--- a/ReactiveExtensions/UIKit/UISwitchTests.swift
+++ b/ReactiveExtensions/UIKit/UISwitchTests.swift
@@ -10,7 +10,7 @@ internal final class UISwitchTests: XCTestCase {
   let uiSwitch = UISwitch()
 
   func testOn() {
-    let (signal, observer) = Signal<Bool, NoError>.pipe()
+    let (signal, observer) = Signal<Bool, Never>.pipe()
     uiSwitch.rac.on = signal
 
     observer.send(value: true)

--- a/ReactiveExtensions/UIKit/UISwitchTests.swift
+++ b/ReactiveExtensions/UIKit/UISwitchTests.swift
@@ -1,7 +1,6 @@
 #if os(iOS)
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UITextField.swift
+++ b/ReactiveExtensions/UIKit/UITextField.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UITextField.swift
+++ b/ReactiveExtensions/UIKit/UITextField.swift
@@ -8,7 +8,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UITextField {
-  public var attributedPlaceholder: Signal<NSAttributedString, NoError> {
+  public var attributedPlaceholder: Signal<NSAttributedString, Never> {
     nonmutating set {
       let prop: MutableProperty<NSAttributedString> = lazyMutableProperty(
         object,
@@ -24,7 +24,7 @@ public extension Rac where Object: UITextField {
     }
   }
 
-  public var text: Signal<String, NoError> {
+  public var text: Signal<String, Never> {
     nonmutating set {
       let prop: MutableProperty<String> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UITextFieldTests.swift
+++ b/ReactiveExtensions/UIKit/UITextFieldTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UITextFieldTests.swift
+++ b/ReactiveExtensions/UIKit/UITextFieldTests.swift
@@ -9,7 +9,7 @@ final class UITextFieldTests: XCTestCase {
   let textField = UITextField()
 
   func testAttributedPlaceHolder() {
-    let (signal, observer) = Signal<NSAttributedString, NoError>.pipe()
+    let (signal, observer) = Signal<NSAttributedString, Never>.pipe()
     textField.rac.attributedPlaceholder = signal
 
     observer.send(value: NSAttributedString(string: "The future"))
@@ -20,7 +20,7 @@ final class UITextFieldTests: XCTestCase {
   }
 
   func testText() {
-    let (signal, observer) = Signal<String, NoError>.pipe()
+    let (signal, observer) = Signal<String, Never>.pipe()
     textField.rac.text = signal
 
     observer.send(value: "The future")

--- a/ReactiveExtensions/UIKit/UITextView.swift
+++ b/ReactiveExtensions/UIKit/UITextView.swift
@@ -7,7 +7,7 @@ private enum Associations {
 }
 
 public extension Rac where Object: UITextView {
-  public var text: Signal<String, NoError> {
+  public var text: Signal<String, Never> {
     nonmutating set {
       let prop: MutableProperty<String> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UITextView.swift
+++ b/ReactiveExtensions/UIKit/UITextView.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UITextViewTests.swift
+++ b/ReactiveExtensions/UIKit/UITextViewTests.swift
@@ -9,7 +9,7 @@ final class UITextViewTests: XCTestCase {
   let textView = UITextView()
 
   func testText() {
-    let (signal, observer) = Signal<String, NoError>.pipe()
+    let (signal, observer) = Signal<String, Never>.pipe()
     textView.rac.text = signal
 
     observer.send(value: "The future")

--- a/ReactiveExtensions/UIKit/UITextViewTests.swift
+++ b/ReactiveExtensions/UIKit/UITextViewTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UIView.swift
+++ b/ReactiveExtensions/UIKit/UIView.swift
@@ -12,7 +12,7 @@ private enum Associations {
 
 public extension Rac where Object: UIView {
 
-  public var alpha: Signal<CGFloat, NoError> {
+  public var alpha: Signal<CGFloat, Never> {
     nonmutating set {
       let prop: MutableProperty<CGFloat> = lazyMutableProperty(object, key: &Associations.alpha,
         setter: { [weak object] in object?.alpha = $0 },
@@ -26,7 +26,7 @@ public extension Rac where Object: UIView {
     }
   }
 
-  public var backgroundColor: Signal<UIColor, NoError> {
+  public var backgroundColor: Signal<UIColor, Never> {
     nonmutating set {
       let prop: MutableProperty<UIColor> = lazyMutableProperty(object, key: &Associations.backgroundColor,
         setter: { [weak object] in object?.backgroundColor = $0 },
@@ -40,7 +40,7 @@ public extension Rac where Object: UIView {
     }
   }
 
-  public var endEditing: Signal<(), NoError> {
+  public var endEditing: Signal<(), Never> {
     nonmutating set {
       let prop: MutableProperty = lazyMutableProperty(object, key: &Associations.endEditing,
         setter: { [weak object] in object?.endEditing(true) },
@@ -54,7 +54,7 @@ public extension Rac where Object: UIView {
     }
   }
 
-  public var hidden: Signal<Bool, NoError> {
+  public var hidden: Signal<Bool, Never> {
     nonmutating set {
       let prop: MutableProperty<Bool> = lazyMutableProperty(object, key: &Associations.hidden,
         setter: { [weak object] in object?.isHidden = $0 },
@@ -68,7 +68,7 @@ public extension Rac where Object: UIView {
     }
   }
 
-  public var tintColor: Signal<UIColor, NoError> {
+  public var tintColor: Signal<UIColor, Never> {
     nonmutating set {
       let prop: MutableProperty<UIColor> = lazyMutableProperty(
         object,

--- a/ReactiveExtensions/UIKit/UIView.swift
+++ b/ReactiveExtensions/UIKit/UIView.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import UIKit
 
 private enum Associations {

--- a/ReactiveExtensions/UIKit/UIViewTests.swift
+++ b/ReactiveExtensions/UIKit/UIViewTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 import UIKit
 @testable import ReactiveExtensions_TestHelpers

--- a/ReactiveExtensions/UIKit/UIViewTests.swift
+++ b/ReactiveExtensions/UIKit/UIViewTests.swift
@@ -10,7 +10,7 @@ final class UIViewTests: XCTestCase {
   let view = UIView()
 
   func testAlpha() {
-    let (signal, observer) = Signal<CGFloat, NoError>.pipe()
+    let (signal, observer) = Signal<CGFloat, Never>.pipe()
     view.rac.alpha = signal
 
     observer.send(value: 0.0)
@@ -21,7 +21,7 @@ final class UIViewTests: XCTestCase {
   }
 
   func testBackgroundColor() {
-    let (signal, observer) = Signal<UIColor, NoError>.pipe()
+    let (signal, observer) = Signal<UIColor, Never>.pipe()
     view.rac.backgroundColor = signal
 
     observer.send(value: .red)
@@ -32,7 +32,7 @@ final class UIViewTests: XCTestCase {
   }
 
   func testEndEditing() {
-    let (signal, observer) = Signal<(), NoError>.pipe()
+    let (signal, observer) = Signal<(), Never>.pipe()
     #if os(iOS)
     let view = UITextView()
     #else
@@ -52,7 +52,7 @@ final class UIViewTests: XCTestCase {
   }
 
   func testHidden() {
-    let (signal, observer) = Signal<Bool, NoError>.pipe()
+    let (signal, observer) = Signal<Bool, Never>.pipe()
     view.rac.hidden = signal
 
     observer.send(value: true)
@@ -78,7 +78,7 @@ final class UIViewTests: XCTestCase {
   func testIsMainThread() {
     let view = MockView()
 
-    let (signal, observer) = Signal<CGFloat, NoError>.pipe()
+    let (signal, observer) = Signal<CGFloat, Never>.pipe()
     view.rac.alpha = signal
 
     let expectation = self.expectation(description: "isMainThread")

--- a/ReactiveExtensions/operators/AllValuesTests.swift
+++ b/ReactiveExtensions/operators/AllValuesTests.swift
@@ -7,7 +7,7 @@ import Result
 final class AllValuesTests: XCTestCase {
 
   func testAllValues() {
-    let producer = SignalProducer<Int, NoError>([1, 2, 3, 4])
+    let producer = SignalProducer<Int, Never>([1, 2, 3, 4])
     XCTAssertEqual([1, 2, 3, 4], producer.allValues())
   }
 }

--- a/ReactiveExtensions/operators/AllValuesTests.swift
+++ b/ReactiveExtensions/operators/AllValuesTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/ConcatTests.swift
+++ b/ReactiveExtensions/operators/ConcatTests.swift
@@ -7,11 +7,11 @@ import Result
 final class ConcatTests: XCTestCase {
 
   func testSignal_Concat() {
-    let (s1, o1) = Signal<Int, NoError>.pipe()
-    let (s2, o2) = Signal<Int, NoError>.pipe()
+    let (s1, o1) = Signal<Int, Never>.pipe()
+    let (s2, o2) = Signal<Int, Never>.pipe()
     let concat = Signal.concat(s1, s2)
 
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     concat.observe(test.observer)
 
     o1.send(value: 1)
@@ -25,14 +25,14 @@ final class ConcatTests: XCTestCase {
   }
 
   func testProducer_Concat() {
-    let (s1, o1) = Signal<Int, NoError>.pipe()
-    let (s2, o2) = Signal<Int, NoError>.pipe()
+    let (s1, o1) = Signal<Int, Never>.pipe()
+    let (s2, o2) = Signal<Int, Never>.pipe()
     let p1 = SignalProducer(s1)
     let p2 = SignalProducer(s2)
 
     let concat = SignalProducer.concat(p1, p2)
 
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     concat.start(test.observer)
 
     o1.send(value: 1)

--- a/ReactiveExtensions/operators/ConcatTests.swift
+++ b/ReactiveExtensions/operators/ConcatTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/DebounceTests.swift
+++ b/ReactiveExtensions/operators/DebounceTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/DebounceTests.swift
+++ b/ReactiveExtensions/operators/DebounceTests.swift
@@ -8,9 +8,9 @@ final class DebounceTests: XCTestCase {
 
   func testDebounce() {
     let scheduler = TestScheduler()
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let debounced = signal.ksr_debounce(.milliseconds(500), on: scheduler)
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     debounced.observe(test.observer)
 
     observer.send(value: 1)

--- a/ReactiveExtensions/operators/DemoteErrors.swift
+++ b/ReactiveExtensions/operators/DemoteErrors.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 
 public extension Signal {
 

--- a/ReactiveExtensions/operators/DemoteErrors.swift
+++ b/ReactiveExtensions/operators/DemoteErrors.swift
@@ -11,7 +11,7 @@ public extension Signal {
 
    - returns: A new signal that will never error.
    */
-  public func demoteErrors(replaceErrorWith value: Value? = nil) -> Signal<Value, NoError> {
+  public func demoteErrors(replaceErrorWith value: Value? = nil) -> Signal<Value, Never> {
 
     return self.signal
       .flatMapError { _ in
@@ -32,7 +32,7 @@ public extension SignalProducer {
 
    - returns: A new producer that will never error.
    */
-  public func demoteErrors(replaceErrorWith value: Value? = nil) -> SignalProducer<Value, NoError> {
+  public func demoteErrors(replaceErrorWith value: Value? = nil) -> SignalProducer<Value, Never> {
     return self.lift { $0.demoteErrors(replaceErrorWith: value) }
   }
 }

--- a/ReactiveExtensions/operators/DemoteErrorsTests.swift
+++ b/ReactiveExtensions/operators/DemoteErrorsTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/DemoteErrorsTests.swift
+++ b/ReactiveExtensions/operators/DemoteErrorsTests.swift
@@ -10,7 +10,7 @@ final class DemoteErrorTests: XCTestCase {
     let (signal, observer) = Signal<Int, SomeError>.pipe()
     let testSignal = signal.demoteErrors()
 
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     testSignal.observe(test.observer)
 
     observer.send(value: 1)
@@ -27,7 +27,7 @@ final class DemoteErrorTests: XCTestCase {
     let (signal, observer) = Signal<Int, SomeError>.pipe()
     let testSignal = signal.demoteErrors(replaceErrorWith: 99)
 
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     testSignal.observe(test.observer)
 
     observer.send(value: 1)
@@ -45,7 +45,7 @@ final class DemoteErrorTests: XCTestCase {
     let producer = SignalProducer(signal)
     let testSignal = producer.demoteErrors()
 
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     testSignal.start(test.observer)
 
     observer.send(value: 1)
@@ -63,7 +63,7 @@ final class DemoteErrorTests: XCTestCase {
     let producer = SignalProducer(signal)
     let testSignal = producer.demoteErrors(replaceErrorWith: 99)
 
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     testSignal.start(test.observer)
 
     observer.send(value: 1)

--- a/ReactiveExtensions/operators/EnumeratedTests.swift
+++ b/ReactiveExtensions/operators/EnumeratedTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/EnumeratedTests.swift
+++ b/ReactiveExtensions/operators/EnumeratedTests.swift
@@ -7,9 +7,9 @@ import Result
 final class EnumeratedTests: XCTestCase {
 
   func testEnumerated() {
-    let (signal, observer) = Signal<String, NoError>.pipe()
-    let testIdx = TestObserver<Int, NoError>()
-    let testValue = TestObserver<String, NoError>()
+    let (signal, observer) = Signal<String, Never>.pipe()
+    let testIdx = TestObserver<Int, Never>()
+    let testValue = TestObserver<String, Never>()
     signal.enumerated().map { idx, _ in idx }.observe(testIdx.observer)
     signal.enumerated().map { _, value in value }.observe(testValue.observer)
 

--- a/ReactiveExtensions/operators/Errors.swift
+++ b/ReactiveExtensions/operators/Errors.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 
 extension Signal where Value: EventProtocol, Error == Never {
   /**

--- a/ReactiveExtensions/operators/Errors.swift
+++ b/ReactiveExtensions/operators/Errors.swift
@@ -1,20 +1,20 @@
 import ReactiveSwift
 import Result
 
-extension Signal where Value: EventProtocol, Error == NoError {
+extension Signal where Value: EventProtocol, Error == Never {
   /**
    - returns: A signal of errors of `Error` events from a materialized signal.
    */
-  public func errors() -> Signal<Value.Error, NoError> {
+  public func errors() -> Signal<Value.Error, Never> {
     return self.signal.map { $0.event.error }.skipNil()
   }
 }
 
-extension SignalProducer where Value: EventProtocol, Error == NoError {
+extension SignalProducer where Value: EventProtocol, Error == Never {
   /**
    - returns: A producer of errors of `Error` events from a materialized signal.
    */
-  public func errors() -> SignalProducer<Value.Error, NoError> {
+  public func errors() -> SignalProducer<Value.Error, Never> {
     return self.lift { $0.errors() }
   }
 }
@@ -25,8 +25,8 @@ extension SignalProducer where Value: EventProtocol, Error == NoError {
  so that all termination events are delayed if required.
  */
 extension Signal {
-  // Turn the producer from a Signal<Result<Value, Error>, NoError> into a Signal<Value, Error>.
-  public func liftSubduedError<T, E>() -> Signal<T, E> where Value == Result<T, E>, Error == NoError {
+  // Turn the producer from a Signal<Result<Value, Error>, Never> into a Signal<Value, Error>.
+  public func liftSubduedError<T, E>() -> Signal<T, E> where Value == Result<T, E>, Error == Never {
     return materialize()
       .map { event -> Signal<T, E>.Event in
         switch event {
@@ -45,10 +45,10 @@ extension Signal {
       .dematerialize()
   }
 
-  // Turn the producer from a Signal<Value, Error> into a Signal<Result<Value, Error>, NoError>.
-  public func subdueError() -> Signal<Result<Value, Error>, NoError> {
+  // Turn the producer from a Signal<Value, Error> into a Signal<Result<Value, Error>, Never>.
+  public func subdueError() -> Signal<Result<Value, Error>, Never> {
     return materialize()
-      .flatMap(.concat) { event -> SignalProducer<Signal<Result<Value, Error>, NoError>.Event, NoError> in
+      .flatMap(.concat) { event -> SignalProducer<Signal<Result<Value, Error>, Never>.Event, Never> in
         switch event {
         case let .value(value):
           return .init(value: .value(.success(value)))
@@ -65,15 +65,15 @@ extension Signal {
 }
 
 extension SignalProducer {
-  // Turn the producer from a SignalProducer<Result<Value, Error>, NoError>
+  // Turn the producer from a SignalProducer<Result<Value, Error>, Never>
   // into a SignalProducer<Value, Error>.
-  public func liftSubduedError<T, E>() -> SignalProducer<T, E> where Value == Result<T, E>, Error == NoError {
+  public func liftSubduedError<T, E>() -> SignalProducer<T, E> where Value == Result<T, E>, Error == Never {
     return lift { $0.liftSubduedError() }
   }
 
   // Turn the producer from a SignalProducer<Value, Error>
-  // into a SignalProducer<Result<Value, Error>, NoError>.
-  public func subdueError() -> SignalProducer<Result<Value, Error>, NoError> {
+  // into a SignalProducer<Result<Value, Error>, Never>.
+  public func subdueError() -> SignalProducer<Result<Value, Error>, Never> {
     return lift { $0.subdueError() }
   }
 }

--- a/ReactiveExtensions/operators/ErrorsTests.swift
+++ b/ReactiveExtensions/operators/ErrorsTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/ErrorsTests.swift
+++ b/ReactiveExtensions/operators/ErrorsTests.swift
@@ -11,8 +11,8 @@ private func failOnEvens(_ idx: Int) -> SignalProducer<Int, SomeError> {
 final class ErrorsTests: XCTestCase {
 
   func testSignalErrors() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
-    let test = TestObserver<SomeError, NoError>()
+    let (signal, observer) = Signal<Int, Never>.pipe()
+    let test = TestObserver<SomeError, Never>()
     signal
       .flatMap { idx in failOnEvens(idx).materialize() }
       .errors()
@@ -29,9 +29,9 @@ final class ErrorsTests: XCTestCase {
   }
 
   func testProducerValues() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let producer = SignalProducer(signal)
-    let test = TestObserver<SomeError, NoError>()
+    let test = TestObserver<SomeError, Never>()
     producer
       .flatMap { idx in failOnEvens(idx).materialize() }
       .errors()

--- a/ReactiveExtensions/operators/MapConstTests.swift
+++ b/ReactiveExtensions/operators/MapConstTests.swift
@@ -7,9 +7,9 @@ import Result
 final class MapConstTests: XCTestCase {
 
   func testSignalMapConst() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let const = signal.mapConst(5)
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     const.observe(test.observer)
 
     observer.send(value: 1)
@@ -26,9 +26,9 @@ final class MapConstTests: XCTestCase {
   }
 
   func testSignalProducerMapConst() {
-    let producer = SignalProducer<Int, NoError>([1, 2, 3, 4])
+    let producer = SignalProducer<Int, Never>([1, 2, 3, 4])
       .mapConst(5)
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     producer.start(test.observer)
 
     test.assertValues([5, 5, 5, 5])

--- a/ReactiveExtensions/operators/MapConstTests.swift
+++ b/ReactiveExtensions/operators/MapConstTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/ScanTests.swift
+++ b/ReactiveExtensions/operators/ScanTests.swift
@@ -7,9 +7,9 @@ import Result
 final class ScanTests: XCTestCase {
 
   func testScan() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let scan = signal.scan { $0 + $1 }
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     scan.observe(test.observer)
 
     observer.send(value: 1)

--- a/ReactiveExtensions/operators/ScanTests.swift
+++ b/ReactiveExtensions/operators/ScanTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/SlidingWindowTest.swift
+++ b/ReactiveExtensions/operators/SlidingWindowTest.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/SlidingWindowTest.swift
+++ b/ReactiveExtensions/operators/SlidingWindowTest.swift
@@ -7,9 +7,9 @@ import Result
 final class SlidingWindowTest: XCTestCase {
 
   func testSlidingWindowWithMaxLessThanMin() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let window = signal.slidingWindow(max: 3, min: 2)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     window.observe(test.observer)
 
     observer.send(value: 1)
@@ -29,9 +29,9 @@ final class SlidingWindowTest: XCTestCase {
   }
 
   func testSlidingWindowWithMinEqualToZero() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let window = signal.slidingWindow(max: 2, min: 0)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     window.observe(test.observer)
 
     observer.send(value: 1)
@@ -48,9 +48,9 @@ final class SlidingWindowTest: XCTestCase {
   }
 
   func testSlidingWindowWithMaxEqualToMin() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let window = signal.slidingWindow(max: 3, min: 3)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     window.observe(test.observer)
 
     observer.send(value: 1)
@@ -70,10 +70,10 @@ final class SlidingWindowTest: XCTestCase {
   }
 
   func testProducer_SlidingWindowWithMaxLessThanMin() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let producer = SignalProducer(signal)
     let window = producer.slidingWindow(max: 3, min: 2)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     window.start(test.observer)
 
     observer.send(value: 1)

--- a/ReactiveExtensions/operators/SortTests.swift
+++ b/ReactiveExtensions/operators/SortTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/SortTests.swift
+++ b/ReactiveExtensions/operators/SortTests.swift
@@ -7,9 +7,9 @@ import Result
 final class SortTests: XCTestCase {
 
   func testSignalSort() {
-    let (signal, observer) = Signal<[Int], NoError>.pipe()
+    let (signal, observer) = Signal<[Int], Never>.pipe()
     let sort = signal.sort()
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     sort.observe(test.observer)
 
     observer.send(value: [2, 1, 3])
@@ -20,9 +20,9 @@ final class SortTests: XCTestCase {
   }
 
   func testSignalSortWithComparator() {
-    let (signal, observer) = Signal<[Int], NoError>.pipe()
+    let (signal, observer) = Signal<[Int], Never>.pipe()
     let sort = signal.sort(>)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     sort.observe(test.observer)
 
     observer.send(value: [2, 1, 3])
@@ -33,18 +33,18 @@ final class SortTests: XCTestCase {
   }
 
   func testSignalProducerSort() {
-    let producer = SignalProducer<[Int], NoError>([[2, 1, 3], [3, 2, 1], [1, 2, 3]])
+    let producer = SignalProducer<[Int], Never>([[2, 1, 3], [3, 2, 1], [1, 2, 3]])
     let sort = producer.sort()
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     sort.start(test.observer)
 
     test.assertValues([[1, 2, 3], [1, 2, 3], [1, 2, 3]])
   }
 
   func testSignalProducerSortWithComparator() {
-    let producer = SignalProducer<[Int], NoError>([[2, 1, 3], [3, 2, 1], [1, 2, 3]])
+    let producer = SignalProducer<[Int], Never>([[2, 1, 3], [3, 2, 1], [1, 2, 3]])
     let sort = producer.sort(>)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     sort.start(test.observer)
 
     test.assertValues([[3, 2, 1], [3, 2, 1], [3, 2, 1]])

--- a/ReactiveExtensions/operators/TakeUntilTests.swift
+++ b/ReactiveExtensions/operators/TakeUntilTests.swift
@@ -7,9 +7,9 @@ import Result
 final class TakeUntilTests: XCTestCase {
 
   func testStandard() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let takeUntil = signal.takeUntil { $0 % 2 == 0 }
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     takeUntil.observe(test.observer)
 
     observer.send(value: 1)

--- a/ReactiveExtensions/operators/TakeUntilTests.swift
+++ b/ReactiveExtensions/operators/TakeUntilTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/TakeWhenTests.swift
+++ b/ReactiveExtensions/operators/TakeWhenTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/TakeWhenTests.swift
+++ b/ReactiveExtensions/operators/TakeWhenTests.swift
@@ -7,10 +7,10 @@ import Result
 final class TakeWhenTests: XCTestCase {
 
   func testStandard() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let takePairWhen = source.takePairWhen(sample)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     takePairWhen.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)
@@ -63,10 +63,10 @@ final class TakeWhenTests: XCTestCase {
   }
 
   func testWithSourceInterrupted() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let takePairWhen = source.takePairWhen(sample)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     takePairWhen.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)
@@ -93,10 +93,10 @@ final class TakeWhenTests: XCTestCase {
   }
 
   func testWithSampleInterrupted() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let takePairWhen = source.takePairWhen(sample)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     takePairWhen.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)
@@ -108,10 +108,10 @@ final class TakeWhenTests: XCTestCase {
   }
 
   func testTakeWhen() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let takeWhen = source.takeWhen(sample)
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     takeWhen.observe(test.observer)
 
     sourceObserver.send(value: 1)

--- a/ReactiveExtensions/operators/UncollectTests.swift
+++ b/ReactiveExtensions/operators/UncollectTests.swift
@@ -7,9 +7,9 @@ import Result
 class UncollectTests: XCTestCase {
 
   func testSignalUncollect() {
-    let (signal, observer) = Signal<[Int], NoError>.pipe()
+    let (signal, observer) = Signal<[Int], Never>.pipe()
     let uncollected = signal.uncollect()
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     uncollected.observe(test.observer)
 
     observer.send(value: [1, 2, 3])
@@ -35,9 +35,9 @@ class UncollectTests: XCTestCase {
   }
 
   func testSignalUncollectInterruption() {
-    let (signal, observer) = Signal<[Int], NoError>.pipe()
+    let (signal, observer) = Signal<[Int], Never>.pipe()
     let uncollected = signal.uncollect()
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     uncollected.observe(test.observer)
 
     observer.send(value: [1, 2, 3])
@@ -48,9 +48,9 @@ class UncollectTests: XCTestCase {
   }
 
   func testSignalProducerUncollect() {
-    let producer = SignalProducer<[Int], NoError>(value: [1, 2, 3])
+    let producer = SignalProducer<[Int], Never>(value: [1, 2, 3])
     let uncollected = producer.uncollect()
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     uncollected.start(test.observer)
 
     test.assertValues([1, 2, 3])

--- a/ReactiveExtensions/operators/UncollectTests.swift
+++ b/ReactiveExtensions/operators/UncollectTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/Values.swift
+++ b/ReactiveExtensions/operators/Values.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 
 extension Signal where Value: EventProtocol, Error == Never {
   /**

--- a/ReactiveExtensions/operators/Values.swift
+++ b/ReactiveExtensions/operators/Values.swift
@@ -1,20 +1,20 @@
 import ReactiveSwift
 import Result
 
-extension Signal where Value: EventProtocol, Error == NoError {
+extension Signal where Value: EventProtocol, Error == Never {
   /**
    - returns: A signal of values of `Next` events from a materialized signal.
    */
-  public func values() -> Signal<Value.Value, NoError> {
+  public func values() -> Signal<Value.Value, Never> {
     return self.signal.map { $0.event.value }.skipNil()
   }
 }
 
-extension SignalProducer where Value: EventProtocol, Error == NoError {
+extension SignalProducer where Value: EventProtocol, Error == Never {
   /**
    - returns: A producer of values of `Next` events from a materialized signal.
    */
-  public func values() -> SignalProducer<Value.Value, NoError> {
+  public func values() -> SignalProducer<Value.Value, Never> {
     return lift { $0.values() }
   }
 }

--- a/ReactiveExtensions/operators/ValuesTests.swift
+++ b/ReactiveExtensions/operators/ValuesTests.swift
@@ -11,8 +11,8 @@ private func failOnEvens(_ idx: Int) -> SignalProducer<Int, SomeError> {
 final class ValuesTests: XCTestCase {
 
   func testSignalValues() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
-    let test = TestObserver<Int, NoError>()
+    let (signal, observer) = Signal<Int, Never>.pipe()
+    let test = TestObserver<Int, Never>()
     signal
       .flatMap { idx in failOnEvens(idx).materialize() }
       .values()
@@ -29,9 +29,9 @@ final class ValuesTests: XCTestCase {
   }
 
   func testProducerValues() {
-    let (signal, observer) = Signal<Int, NoError>.pipe()
+    let (signal, observer) = Signal<Int, Never>.pipe()
     let producer = SignalProducer(signal)
-    let test = TestObserver<Int, NoError>()
+    let test = TestObserver<Int, Never>()
     producer
       .flatMap { idx in failOnEvens(idx).materialize() }
       .values()

--- a/ReactiveExtensions/operators/ValuesTests.swift
+++ b/ReactiveExtensions/operators/ValuesTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/WithLatestFromTests.swift
+++ b/ReactiveExtensions/operators/WithLatestFromTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 

--- a/ReactiveExtensions/operators/WithLatestFromTests.swift
+++ b/ReactiveExtensions/operators/WithLatestFromTests.swift
@@ -7,10 +7,10 @@ import Result
 final class WithLatestFromTests: XCTestCase {
 
   func testWithLatestFromSignal() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let withLatestFrom = sample.withLatestFrom(source)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)
@@ -63,10 +63,10 @@ final class WithLatestFromTests: XCTestCase {
   }
 
   func testWithLatestFromSignal_SourceInterrupted() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let withLatestFrom = sample.withLatestFrom(source)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)
@@ -93,10 +93,10 @@ final class WithLatestFromTests: XCTestCase {
   }
 
   func testWithLatestFromSignal_SampleInterrupted() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let withLatestFrom = sample.withLatestFrom(source)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)
@@ -108,11 +108,11 @@ final class WithLatestFromTests: XCTestCase {
   }
 
   func testWithLatestFromProducer() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)
@@ -137,11 +137,11 @@ final class WithLatestFromTests: XCTestCase {
   }
 
   func testWithLatestFromProducer_SourceCompleting() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)
@@ -170,11 +170,11 @@ final class WithLatestFromTests: XCTestCase {
   }
 
   func testWithLatestFromProducer_SourceInterrupted() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)
@@ -203,11 +203,11 @@ final class WithLatestFromTests: XCTestCase {
   }
 
   func testWithLatestFromProducer_SampleInterrupted() {
-    let (source, sourceObserver) = Signal<Int, NoError>.pipe()
-    let (sample, sampleObserver) = Signal<Int, NoError>.pipe()
+    let (source, sourceObserver) = Signal<Int, Never>.pipe()
+    let (sample, sampleObserver) = Signal<Int, Never>.pipe()
     let sourceProducer = SignalProducer(source)
     let withLatestFrom = sample.withLatestFrom(sourceProducer)
-    let test = TestObserver<[Int], NoError>()
+    let test = TestObserver<[Int], Never>()
     withLatestFrom.map { [$0, $1] }.observe(test.observer)
 
     sourceObserver.send(value: 1)

--- a/ReactiveExtensions/test-helpers/TestObserver.swift
+++ b/ReactiveExtensions/test-helpers/TestObserver.swift
@@ -8,7 +8,7 @@ import ReactiveSwift
  wrapped observer. For example,
 
  ```
- let test = TestObserver<Int, NoError>()
+ let test = TestObserver<Int, Never>()
  mySignal.observer(test.observer)
 
  // ... later ...


### PR DESCRIPTION
Updates to ReactiveSwift [6.0.0](https://github.com/ReactiveCocoa/ReactiveSwift/releases/tag/6.0.0):

- Removes `Result`.
- `NoError` -> `Never`.
- `AnyError` -> `Error`.