### PR TITLE
[NT-724] Xcode 11/Swift 5.1 updates

### DIFF
--- a/ReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ReactiveExtensions.xcodeproj/project.pbxproj
@@ -750,7 +750,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Kickstarter;
 				TargetAttributes = {
 					A7983B871C2AFB1C003A1ABE = {
@@ -759,7 +759,7 @@
 					};
 					A7DB1D391C9F355E008244DA = {
 						CreatedOnToolsVersion = 7.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1130;
 					};
 					A7DB1D4C1C9F4FD7008244DA = {
 						LastSwiftMigration = 0800;
@@ -778,11 +778,11 @@
 			};
 			buildConfigurationList = CA43C65D1BB35FCF00C180DA /* Build configuration list for PBXProject "ReactiveExtensions" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = CA43C6591BB35FCF00C180DA;
 			productRefGroup = CA43C6641BB35FCF00C180DA /* Products */;
@@ -1198,7 +1198,7 @@
 				PRODUCT_NAME = ReactiveExtensions_TestHelpers;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1228,7 +1228,7 @@
 				PRODUCT_NAME = ReactiveExtensions_TestHelpers;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1362,6 +1362,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1425,6 +1426,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/ReactiveExtensions.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ReactiveExtensions.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>BuildSystemType</key>
-	<string>Original</string>
+	<string>Latest</string>
 </dict>
 </plist>

--- a/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-TestHelpers-iOS.xcscheme
+++ b/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-TestHelpers-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:ReactiveExtensions.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-TestHelpers-tvOS.xcscheme
+++ b/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-TestHelpers-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:ReactiveExtensions.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-iOS.xcscheme
+++ b/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,8 +40,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7FD08861C81EDBD00332CCB"
+            BuildableName = "ReactiveExtensions.framework"
+            BlueprintName = "ReactiveExtensions-iOS"
+            ReferencedContainer = "container:ReactiveExtensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,17 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "A7FD08861C81EDBD00332CCB"
-            BuildableName = "ReactiveExtensions.framework"
-            BlueprintName = "ReactiveExtensions-iOS"
-            ReferencedContainer = "container:ReactiveExtensions.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -85,8 +83,6 @@
             ReferencedContainer = "container:ReactiveExtensions.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-tvOS.xcscheme
+++ b/ReactiveExtensions.xcodeproj/xcshareddata/xcschemes/ReactiveExtensions-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,8 +40,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CA43C6621BB35FCF00C180DA"
+            BuildableName = "ReactiveExtensions.framework"
+            BlueprintName = "ReactiveExtensions-tvOS"
+            ReferencedContainer = "container:ReactiveExtensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,17 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CA43C6621BB35FCF00C180DA"
-            BuildableName = "ReactiveExtensions.framework"
-            BlueprintName = "ReactiveExtensions-tvOS"
-            ReferencedContainer = "container:ReactiveExtensions.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -85,8 +83,6 @@
             ReferencedContainer = "container:ReactiveExtensions.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ReactiveExtensions/operators/AllValues.swift
+++ b/ReactiveExtensions/operators/AllValues.swift
@@ -11,7 +11,12 @@ public extension SignalProducer {
 
    - returns: All values emitted by the signal producer.
    */
-  public func allValues() -> [Value] {
-    return self.producer.collect().last()?.value ?? []
+  func allValues() -> [Value] {
+    switch self.producer.collect().last() {
+    case .success(let value):
+      return value
+    default:
+      return []
+    }
   }
 }

--- a/ReactiveExtensions/test-helpers/Event-Extensions.swift
+++ b/ReactiveExtensions/test-helpers/Event-Extensions.swift
@@ -1,21 +1,21 @@
 import ReactiveSwift
 
 internal extension Signal.Event {
-  internal var isValue: Bool {
+  var isValue: Bool {
     if case .value = self {
       return true
     }
     return false
   }
 
-  internal var isFailed: Bool {
+  var isFailed: Bool {
     if case .failed = self {
       return true
     }
     return false
   }
 
-  internal var isInterrupted: Bool {
+  var isInterrupted: Bool {
     if case .interrupted = self {
       return true
     }

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "10.2.1"
+      xcode: "11.3.0"
     working_directory: ~/ReactiveExtensions
     environment:
       CIRCLE_ARTIFACTS: /tmp
@@ -18,8 +18,8 @@ jobs:
       - run: set -o pipefail &&
           swiftlint lint --strict --reporter json |
           tee $CIRCLE_ARTIFACTS/swiftlint-report.json
-      - run: bin/test iOS 11.4
-      - run: bin/test iOS 12.2
+      - run: bin/test iOS 12.4
+      - run: bin/test iOS 13.3
 
       - store_artifacts:
           path: /tmp/swiftlint-report.json


### PR DESCRIPTION
Does:

- Updates ReactiveExtensions to compile in Xcode 11 and Swift 5.1.

Does not:

- Silence all warnings. These will be addressed in a subsequent PR.