### PR TITLE
Xcode 14.5 update: changing linker flags for TestHelpers target.

### DIFF
--- a/ReactiveExtensions.xcodeproj/project.pbxproj
+++ b/ReactiveExtensions.xcodeproj/project.pbxproj
@@ -1192,7 +1192,7 @@
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.reactiveextensions.testhelpers;
 				PRODUCT_NAME = ReactiveExtensions_TestHelpers;
@@ -1222,7 +1222,7 @@
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.reactiveextensions.testhelpers;
 				PRODUCT_NAME = ReactiveExtensions_TestHelpers;


### PR DESCRIPTION
We're using the Xcode 14.5 release candidate to prepare for the next iOS release and need to update some of the Build Settings for compilation.